### PR TITLE
Set site URL for custom domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,7 @@ title: "Maintenance Scripts"
 tagline: "ITAdmin PowerShell Maintenance Scripts"
 description: "A repository of PowerShell Scripts to automate a variety of IT related maintenance tasks."
 baseurl: "/"
+url: https://scripts.lukeleigh.com
 
 author:
   name: "Luke Leigh"


### PR DESCRIPTION
## Summary
- add the production domain to `_config.yml` so generated links use https://scripts.lukeleigh.com

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68cddbc70a30832db455c77e0165d30c