### PR TITLE
Add robots.txt with sitemap directives

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://scripts.lukeleigh.com/sitemap.xml


### PR DESCRIPTION
## Summary
- add a robots.txt file at the site root
- allow all crawlers and reference the public sitemap

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68cddbc0c21c832d80e5183444753cb1