### PR TITLE
feat: add dynamic meta descriptions

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "404: Page not found"
+description: "404 error page that guides visitors back to the script repository homepage."
 permalink: 404.html
 ---
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,8 +5,7 @@
     <meta http-equiv="cache-control" content="public, max-age=604800, immutable">
     <meta name="keywords"
         content="PowerShell, Scripts, Functions, Snippets, Tools, Maintenance, Information Technology, Administration, Download, Automation, Learning">
-    <meta name="description"
-        content="This site was created as a catalogue for all the scripts, functions, tools and snippets I have written, downloaded or amended while learning how to automate and develop PowerShell tools.">
+    <meta name="description" content="{{ page.description | default: page.excerpt | default: site.description }}">
 
     <!-- Enable responsiveness on mobile devices-->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">

--- a/_pages/menu/UserAdminModule.md
+++ b/_pages/menu/UserAdminModule.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: UserAdminModule
+description: "Documentation index for the UserAdminModule PowerShell toolkit and its commands."
 permalink: /menu/_pages/UserAdminModule.html
 ---
 

--- a/_pages/menu/about.md
+++ b/_pages/menu/about.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: about
+description: "Background on Luke Leigh and the goals of the PowerShell script catalogue."
 permalink: /menu/_pages/about.html
 ---
 

--- a/_pages/menu/functions.md
+++ b/_pages/menu/functions.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: functions
+description: "Browse reusable PowerShell functions grouped by administration topic."
 permalink: /menu/_pages/functions.html
 ---
 

--- a/_pages/menu/gists.md
+++ b/_pages/menu/gists.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: gists
+description: "Embedded GitHub Gists highlighting smaller PowerShell utilities and experiments."
 permalink: /menu/_pages/gists.html
 ---
 

--- a/_pages/menu/modules.md
+++ b/_pages/menu/modules.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: modules
+description: "Summary of published PowerShell modules with links to the PowerShell Gallery."
 permalink: /menu/_pages/modules.html
 ---
 

--- a/_pages/menu/myProfile.md
+++ b/_pages/menu/myProfile.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: myProfile
+description: "Luke's personal PowerShell profile modules and helper functions organized by area."
 permalink: /menu/_pages/myProfile.html
 ---
 

--- a/_pages/menu/new⭐.md
+++ b/_pages/menu/new⭐.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: new ⭐
+description: "Spotlight on newly added scripts and functions with quick navigation links."
 permalink: /menu/_pages/new.html
 ---
 

--- a/_pages/menu/resources.md
+++ b/_pages/menu/resources.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: resources
+description: "Curated external resources for learning and extending PowerShell automation."
 permalink: /menu/_pages/resources.html
 ---
 

--- a/_pages/menu/scripts.md
+++ b/_pages/menu/scripts.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: scripts
+description: "Directory of complete PowerShell scripts covering Active Directory, Exchange, and more."
 permalink: /menu/_pages/scripts.html
 ---
 

--- a/_pages/menu/snippets.md
+++ b/_pages/menu/snippets.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: snippets
+description: "Quick PowerShell snippets for frequent administrative tasks."
 permalink: /menu/_pages/snippets.html
 ---
 

--- a/_pages/menu/tools.md
+++ b/_pages/menu/tools.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: tools
+description: "Collection of larger PowerShell tools for automation, reporting, and remediation."
 permalink: /menu/_pages/tools.html
 ---
 

--- a/_posts/UserAdminModule/Connect-O365Exchange.md
+++ b/_posts/UserAdminModule/Connect-O365Exchange.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Connect-O365Exchange.ps1
+description: "Connects to Exchange Online with modern authentication via the ExchangeOnlineManagement module."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Connect-O365Exchange/
 categories:

--- a/_posts/UserAdminModule/Connect-OPExchange.md
+++ b/_posts/UserAdminModule/Connect-OPExchange.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Connect-OPExchange.ps1
+description: "Opens a remote session to on-premises Exchange servers using a randomly selected host."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Connect-OPExchange/
 categories:

--- a/_posts/UserAdminModule/Copy-FilestoRemote.md
+++ b/_posts/UserAdminModule/Copy-FilestoRemote.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Copy-FilestoRemote.ps1
+description: "Copies local files to remote systems over PowerShell remoting with optional credentials."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Copy-FilestoRemote/
 categories:

--- a/_posts/UserAdminModule/Copy-GroupMembership.md
+++ b/_posts/UserAdminModule/Copy-GroupMembership.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Copy-GroupMembership.ps1
+description: "Duplicates group memberships from a source Active Directory user to another account."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Copy-GroupMembership/
 categories:

--- a/_posts/UserAdminModule/Disable-RDPRemotely.md
+++ b/_posts/UserAdminModule/Disable-RDPRemotely.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Disable-RDPRemotely.ps1
+description: "Turns off Remote Desktop Protocol on specified computers via WMI or CIM."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Disable-RDPRemotely/
 categories:

--- a/_posts/UserAdminModule/Enable-RDPRemotely.md
+++ b/_posts/UserAdminModule/Enable-RDPRemotely.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Enable-RDPRemotely.ps1
+description: "Enables Remote Desktop access on remote computers across mixed PowerShell versions."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Enable-RDPRemotely/
 categories:

--- a/_posts/UserAdminModule/Get-ExchangeServerInSite.md
+++ b/_posts/UserAdminModule/Get-ExchangeServerInSite.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-ExchangeServerInSite.ps1
+description: "Lists Exchange servers located in the current Active Directory site."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Get-ExchangeServerInSite/
 categories:

--- a/_posts/UserAdminModule/Get-FileAndFolderPermissions.md
+++ b/_posts/UserAdminModule/Get-FileAndFolderPermissions.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-FileAndFolderPermissions.ps1
+description: "Reports NTFS permissions for files or folders with optional recursion."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Get-FileAndFolderPermissions/
 categories:

--- a/_posts/UserAdminModule/Get-LoggedOnRDPUser.md
+++ b/_posts/UserAdminModule/Get-LoggedOnRDPUser.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-LoggedOnRDPUser.ps1
+description: "Returns currently logged-on RDP users across one or more servers."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Get-LoggedOnRDPUser/
 categories:

--- a/_posts/UserAdminModule/Get-MSTeamsPhone.md
+++ b/_posts/UserAdminModule/Get-MSTeamsPhone.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-MSTeamsPhone.ps1
+description: "Retrieves Microsoft Teams phone assignment details for a given user."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Get-MSTeamsPhone/
 categories:

--- a/_posts/UserAdminModule/Get-O365CalendarPermissions.md
+++ b/_posts/UserAdminModule/Get-O365CalendarPermissions.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-O365CalendarPermissions.ps1
+description: "Gets the calendar permissions assigned to a Microsoft 365 mailbox."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Get-O365CalendarPermissions/
 categories:

--- a/_posts/UserAdminModule/Get-ScheduledTasks.md
+++ b/_posts/UserAdminModule/Get-ScheduledTasks.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-ScheduledTasks.ps1
+description: "Enumerates scheduled tasks on remote servers with filtering support."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Get-ScheduledTasks/
 categories:

--- a/_posts/UserAdminModule/Get-ServerInstalledFeatures.md
+++ b/_posts/UserAdminModule/Get-ServerInstalledFeatures.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-ServerInstalledFeatures.ps1
+description: "Queries remote servers for installed Windows features via Get-WindowsFeature."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Get-ServerInstalledFeatures/
 categories:

--- a/_posts/UserAdminModule/Install-PSTools.md
+++ b/_posts/UserAdminModule/Install-PSTools.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Install-PSTools.ps1
+description: "Downloads, installs, or removes the Sysinternals PSTools suite."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Install-PSTools/
 categories:

--- a/_posts/UserAdminModule/Install-RequiredModules.md
+++ b/_posts/UserAdminModule/Install-RequiredModules.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Install-RequiredModules.ps1
+description: "Ensures required modules and RSAT components are installed before running scripts."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Install-RequiredModules/
 categories:

--- a/_posts/UserAdminModule/New-CountdownDate.md
+++ b/_posts/UserAdminModule/New-CountdownDate.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: New-CountdownDate.ps1
+description: "Creates countdown objects that show days remaining until a specified date."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/New-CountdownDate/
 categories:

--- a/_posts/UserAdminModule/New-MSTeamsPhone.md
+++ b/_posts/UserAdminModule/New-MSTeamsPhone.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: New-MSTeamsPhone.ps1
+description: "Assigns a phone number to a Microsoft Teams user using provided credentials."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/New-MSTeamsPhone/
 categories:

--- a/_posts/UserAdminModule/Remove-RDPUserSession.md
+++ b/_posts/UserAdminModule/Remove-RDPUserSession.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Remove-RDPUserSession.ps1
+description: "Wraps QUser to inspect and disconnect Remote Desktop sessions programmatically."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Remove-RDPUserSession/
 categories:

--- a/_posts/UserAdminModule/Set-O365CalendarPermissions.md
+++ b/_posts/UserAdminModule/Set-O365CalendarPermissions.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Set-O365CalendarPermissions.ps1
+description: "Applies or removes Microsoft 365 calendar permissions for specified users."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Set-O365CalendarPermissions/
 categories:

--- a/_posts/UserAdminModule/Sync-DomainController.md
+++ b/_posts/UserAdminModule/Sync-DomainController.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Sync-DomainController.ps1
+description: "Forces replication across domain controllers within a given domain."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Sync-DomainController/
 categories:

--- a/_posts/UserAdminModule/Test-Computer.md
+++ b/_posts/UserAdminModule/Test-Computer.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Test-Computer.ps1
+description: "Runs connectivity and service checks to summarize a computer's health."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Test-Computer/
 categories:

--- a/_posts/UserAdminModule/Test-O365EmailExists.md
+++ b/_posts/UserAdminModule/Test-O365EmailExists.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Test-O365EmailExists.ps1
+description: "Checks whether an Office 365 mailbox exists and returns identity details."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Test-O365EmailExists/
 categories:

--- a/_posts/UserAdminModule/Test-OpenPorts.md
+++ b/_posts/UserAdminModule/Test-OpenPorts.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Test-OpenPorts.ps1
+description: "Leverages Test-NetConnection to verify common or custom TCP ports on hosts."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Test-OpenPorts/
 categories:

--- a/_posts/UserAdminModule/Update-O365CalendarPermissions.md
+++ b/_posts/UserAdminModule/Update-O365CalendarPermissions.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Update-O365CalendarPermissions.ps1
+description: "Updates existing Microsoft 365 calendar permissions with new roles or removes access."
 date: 2025-09-19
 permalink: /_posts/UserAdminModule/Update-O365CalendarPermissions/
 categories:

--- a/_posts/new/ArgumentCompleterExample.md
+++ b/_posts/new/ArgumentCompleterExample.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: ArgumentCompleterExample.ps1
+description: "Demonstrates using an ArgumentCompleter to tab-complete Exchange server names when connecting."
 ---
 
 - [Description](#description)

--- a/_posts/new/Blank_Page.md
+++ b/_posts/new/Blank_Page.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Blank-Page.ps1
+description: "Starter template for drafting new PowerShell script posts on the site."
 ---
 
 - [Description](#description)

--- a/_posts/new/Connect-Proxy.md
+++ b/_posts/new/Connect-Proxy.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Connect-Proxy.ps1
+description: "Shows how to create a proxy-aware WebClient for authenticated downloads and API calls."
 ---
 
 - [Description](#description)

--- a/_posts/new/Export-CalendarPermissions.md
+++ b/_posts/new/Export-CalendarPermissions.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Export-CalendarPermissions.ps1
+description: "Exports calendar permissions from Exchange or Microsoft 365 mailboxes to CSV for auditing."
 ---
 
 - [Description](#description)

--- a/_posts/new/FileWatcher.md
+++ b/_posts/new/FileWatcher.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: FileWatcher.ps1
+description: "Monitors folders with FileSystemWatcher and logs file changes to a text file."
 ---
 
 - [Description](#description)

--- a/_posts/new/Get-FileExtension.md
+++ b/_posts/new/Get-FileExtension.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-FileExtension.ps1
+description: "Retrieves file extension metadata from an online JSON catalog to classify file types."
 ---
 
 - [Description](#description)

--- a/_posts/new/Get-GroupMembers.md
+++ b/_posts/new/Get-GroupMembers.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-GroupMembers.ps1
+description: "Collects detailed membership information for Active Directory groups."
 ---
 
 - [Description](#description)

--- a/_posts/new/Get-GroupNames.md
+++ b/_posts/new/Get-GroupNames.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-GroupNames.ps1
+description: "Searches Active Directory for groups by name pattern and outputs their details."
 ---
 
 - [Description](#description)

--- a/_posts/new/Get-IISCertificates.md
+++ b/_posts/new/Get-IISCertificates.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-IISCertificates.ps1
+description: "Inventories IIS HTTPS bindings and the SSL certificates assigned to each site."
 ---
 
 - [Description](#description)

--- a/_posts/new/Get-LogonEvent.md
+++ b/_posts/new/Get-LogonEvent.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-LogonEvent.ps1
+description: "Parses Winlogon events to report recent logon and logoff activity on Windows systems."
 ---
 
 - [Description](#description)

--- a/_posts/new/Get-O365AdminGroupsReport.md
+++ b/_posts/new/Get-O365AdminGroupsReport.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-O365AdminGroupsReport.ps1
+description: "Generates a CSV report of Office 365 administrative roles and their assigned members."
 ---
 
 - [Description](#description)

--- a/_posts/new/Get-ServiceDetails.md
+++ b/_posts/new/Get-ServiceDetails.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Get-ServiceDetails.ps1
+description: "Queries remote computers for service status and configuration details by display name."
 ---
 
 - [Description](#description)

--- a/_posts/new/Ifnotpwsh7.md
+++ b/_posts/new/Ifnotpwsh7.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Ifnotpwsh7.ps1
+description: "Example logic that branches actions based on whether PowerShell 6 or later is available."
 ---
 
 - [Description](#description)

--- a/_posts/new/Logoff-Stale-RDP.md
+++ b/_posts/new/Logoff-Stale-RDP.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Blank-Page.ps1
+description: "Logs off disconnected or stale Remote Desktop sessions across target servers."
 ---
 
 - [Description](#description)

--- a/_posts/new/New-Greeting1.md
+++ b/_posts/new/New-Greeting1.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: New-Greeting1.ps1
+description: "Builds day-specific greeting messages using PowerShell hash tables."
 ---
 
 - [Description](#description)

--- a/_posts/new/New-Greeting2.md
+++ b/_posts/new/New-Greeting2.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: New-Greeting2.ps1
+description: "Outputs ASCII-art greetings for each weekday using a custom class."
 ---
 
 - [Description](#description)

--- a/_posts/new/New-SpeechOutput.md
+++ b/_posts/new/New-SpeechOutput.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Blank-Page.ps1
+description: "Uses System.Speech to speak supplied text aloud from PowerShell."
 ---
 
 - [Description](#description)

--- a/_posts/new/Restart-ExchangeServices.md
+++ b/_posts/new/Restart-ExchangeServices.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Restart-ExchangeServices.ps1
+description: "Restarts Exchange-related Windows services on remote servers with optional credentials."
 ---
 
 - [Description](#description)

--- a/_posts/new/Restart-ProjectComputer.md
+++ b/_posts/new/Restart-ProjectComputer.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Restart-ProjectComputer.ps1
+description: "Forcibly restarts project computers and waits for them to come back online."
 ---
 
 - [Description](#description)

--- a/_posts/new/TimeZoneFunctions.md
+++ b/_posts/new/TimeZoneFunctions.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Blank-Page.ps1
+description: "Provides functions to get or set server time zones across multiple computers."
 ---
 
 - [Description](#description)

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: index
 title: home
+description: "Welcome page for Luke Leigh's PowerShell script repository and download hub."
 header:
 teaser: /assets/menu/scripts-blog-intro.gif
 ---


### PR DESCRIPTION
## Summary
- use the page description/excerpt fallback when rendering the head meta description
- add description front matter to key navigation pages and highlighted posts so metadata is meaningful

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68cddbcc9ef4832dad4eeb925cec5444