### PR TITLE
Fix Azure pipeline and repair liquid templates

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,13 +5,14 @@ description: "404 error page that guides visitors back to the script repository 
 permalink: 404.html
 ---
 
-<a href="/" {{ absolute_url }}><img src="/assets/images/404.gif" title="404 - Go Home" alt="404 - Go Home" width="300"
+<a href="{{ '/' | absolute_url }}"><img src="/assets/images/404.gif" title="404 - Go Home" alt="404 - Go Home" width="300"
     height="225"></a><br>
 
 <div class="page">
   <h1 class="page-title">404: Page not found</h1>
   <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist.<br>
     This site is still being created and pages are being added regularly, some links may fail.</p>
-  <p><a href="/" {{ absolute_url }} title="404 - Go Home" alt="404 - Go Home">Head back home</a> to try finding it
+  <p><a href="{{ '/' | absolute_url }}" title="404 - Go Home" alt="404 - Go Home">Head back home</a> to try finding it
     again.</p>
 </div>
+

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,11 +11,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
     <!-- CSS -->
-    <link rel="stylesheet" href="{{ " /assets/css/poole.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/syntax.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/hyde.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/lightbox/css/lightbox.min.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/themes.css" }}">
+    <link rel="stylesheet" href="{{ "/assets/css/poole.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/syntax.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/hyde.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/lightbox/css/lightbox.min.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/themes.css" | relative_url }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Exo+2:wght@500&display=swap">
 
     <!-- buttons.github.io -->
@@ -28,16 +28,16 @@
         crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
     <!-- lightbox -->
-    <script src="{{ " /assets/css/lightbox/js/lightbox-plus-jquery.js" }}"></script>
+    <script src="{{ "/assets/css/lightbox/js/lightbox-plus-jquery.js" | relative_url }}"></script>
 
     <!-- js.cookie for theming -->
-    <script src="{{ " /assets/js/js.cookie.min.js" }}"></script>
+    <script src="{{ "/assets/js/js.cookie.min.js" | relative_url }}"></script>
 
     <!-- site -->
-    <script src="{{ " /assets/js/site.js" }}"></script>
+    <script src="{{ "/assets/js/site.js" | relative_url }}"></script>
 
     <!-- Icons -->
-    <link rel="shortcut icon" href="{{ absolute_url }}/favicon.ico">
+    <link rel="shortcut icon" href="{{ '/favicon.ico' | absolute_url }}">
 
     <!-- RSS -->
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
@@ -82,3 +82,4 @@
     </script>
     <!-- End Microsoft Clarity Analytics -->
 </head>
+

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,7 @@
     <div class="container sidebar-sticky">
         <div class="sidebar-about">
             <h1>
-                <a href="/" {{ absolute_url }}>
+                <a href="{{ '/' | absolute_url }}">
                     <img src="/assets/images/site-logo-small.gif" alt="Site Logo Image">
                     {{ site.title }}
                 </a>
@@ -11,8 +11,8 @@
         </div>
 
         <nav class="sidebar-nav">
-            <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="/" {{ absolute_url
-                }}>Home</a>
+            <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}"
+                href="{{ '/' | absolute_url }}">Home</a>
 
             {% comment %}
             The code below dynamically generates a sidebar nav of pages with

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,24 @@ steps:
 - task: UseRubyVersion@0
   displayName: 'Select Ruby version'
   inputs:
-    bundle exec jekyll build --future
-    ls -la _site
+    versionSpec: '>= 3.1'
+    addToPath: true
+
+- script: |
+    gem install bundler
+    bundle config set --local path vendor/bundle
+    bundle install --jobs 4 --retry 3
+  displayName: 'Install Ruby gems'
+
+- script: bundle exec jekyll build --future
   displayName: 'Build Jekyll site'
+
+- script: ls -la _site
+  displayName: 'List generated site contents'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish site artifact'
+  inputs:
+    PathtoPublish: '_site'
+    ArtifactName: 'jekyll-site'
+    publishLocation: 'Container'

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 header:
-teaser: /assets/menu/scripts-blog-intro.gif
+  teaser: /assets/menu/scripts-blog-intro.gif
 ---
 
 <h1 class="page-title">scripts.lukeleigh.com</h1>
@@ -43,7 +43,7 @@ teaser: /assets/menu/scripts-blog-intro.gif
         be used to produce reports on things like printing or active directory content/configuration.<br>
         <br>
         PowerShell has been available since Microsoft published the first <a
-            href="https://en.wikipedia.org/wiki/PowerShell"></a>Monad</a> (PowerShell) public beta release on
+            href="https://en.wikipedia.org/wiki/Windows_PowerShell#History">Monad</a> (PowerShell) public beta release on
         June 17, 2005. The once small collection of sites has grown into a wealth of information about this
         extraordinarily versatile product and include sites like <a href="https://github.com">GitHub</a>, Microsoft's
         own <a href="https://docs.microsoft.com/en-us/powershell/">Docs site</a> and numerous others which you may find


### PR DESCRIPTION
## Summary
- restore the Azure Pipelines definition so it installs gems, builds the Jekyll site, and publishes the artifact
- fix homepage and sidebar markup issues, including proper YAML front matter and corrected links
- update the head include to use Jekyll URL helpers for local assets and the 404 page links

## Testing
- bundle exec jekyll build --future

------
https://chatgpt.com/codex/tasks/task_e_68cdf0a83154832d9327a22aa3c4862a