### PR TITLE
fix: restore css includes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,11 +11,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
     <!-- CSS -->
-    <link rel="stylesheet" href="{{ " /assets/css/poole.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/syntax.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/hyde.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/lightbox/css/lightbox.min.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/themes.css" }}">
+    <link rel="stylesheet" href="{{ "/assets/css/poole.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/syntax.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/hyde.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/lightbox/css/lightbox.min.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/themes.css" | relative_url }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Exo+2:wght@500&display=swap">
 
     <!-- buttons.github.io -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,11 +11,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
     <!-- CSS -->
-    <link rel="stylesheet" href="{{ "/assets/css/poole.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/syntax.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/hyde.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/lightbox/css/lightbox.min.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/themes.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ " /assets/css/poole.css" }}">
+    <link rel="stylesheet" href="{{ " /assets/css/syntax.css" }}">
+    <link rel="stylesheet" href="{{ " /assets/css/hyde.css" }}">
+    <link rel="stylesheet" href="{{ " /assets/css/lightbox/css/lightbox.min.css" }}">
+    <link rel="stylesheet" href="{{ " /assets/css/themes.css" }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Exo+2:wght@500&display=swap">
 
     <!-- buttons.github.io -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,11 +9,11 @@
     <meta name="description" content="This site was created as a catalogue for all the scripts, functions, tools and snippets I have written, downloaded or amended while learning how to automate and develop PowerShell tools.">
 
     <!-- CSS -->
-    <link rel="stylesheet" href="{{ "/assets/css/poole.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/syntax.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/hyde.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/lightbox/css/lightbox.min.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/assets/css/themes.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ " /assets/css/poole.css" }}">
+    <link rel="stylesheet" href="{{ " /assets/css/syntax.css" }}">
+    <link rel="stylesheet" href="{{ " /assets/css/hyde.css" }}">
+    <link rel="stylesheet" href="{{ " /assets/css/lightbox/css/lightbox.min.css" }}">
+    <link rel="stylesheet" href="{{ " /assets/css/themes.css" }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Exo+2:wght@500&display=swap">
 
     <!-- Icons -->


### PR DESCRIPTION
## Summary
- restore the default layout head to reference the original theme stylesheet asset paths
- revert the head include snippet to the prior stylesheet href values so the theme CSS loads again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdf5f5a19c832da217e9c996298d7b