### PR TITLE
fix: restore CSS links and add pipeline validation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,11 +9,11 @@
     <meta name="description" content="This site was created as a catalogue for all the scripts, functions, tools and snippets I have written, downloaded or amended while learning how to automate and develop PowerShell tools.">
 
     <!-- CSS -->
-    <link rel="stylesheet" href="{{ " /assets/css/poole.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/syntax.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/hyde.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/lightbox/css/lightbox.min.css" }}">
-    <link rel="stylesheet" href="{{ " /assets/css/themes.css" }}">
+    <link rel="stylesheet" href="{{ "/assets/css/poole.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/syntax.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/hyde.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/lightbox/css/lightbox.min.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/themes.css" | relative_url }}">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Exo+2:wght@500&display=swap">
 
     <!-- Icons -->

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,9 @@ steps:
 - script: ls -la _site
   displayName: 'List generated site contents'
 
+- script: pwsh -File build/Verify-CssLink.ps1 -SiteRoot "$(Build.SourcesDirectory)/_site" -CssHint "hyde.css"
+  displayName: 'Verify CSS linked in built site'
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish site artifact'
   inputs:

--- a/build/Verify-CssLink.ps1
+++ b/build/Verify-CssLink.ps1
@@ -1,0 +1,26 @@
+Param(
+  [Parameter(Mandatory)][string]$SiteRoot,   # e.g. "$(Build.SourcesDirectory)/_site" or "dist"
+  [Parameter(Mandatory)][string]$CssHint     # e.g. "main.css" or "app"
+)
+$ErrorActionPreference = 'Stop'
+
+# Find a plausible main CSS file (largest match by name)
+$css = Get-ChildItem -Path $SiteRoot -Recurse -Include *.css |
+       Where-Object { $_.Name -match [Regex]::Escape($CssHint) } |
+       Sort-Object Length -Descending | Select-Object -First 1
+if (-not $css) { throw "No CSS matching '$CssHint' under $SiteRoot." }
+if ($css.Length -le 256) { throw "CSS '$($css.FullName)' appears too small to be valid." }
+
+# Ensure at least one HTML references it
+$htmls = Get-ChildItem -Path $SiteRoot -Recurse -Include index.html,*.html
+if (-not $htmls) { throw "No HTML found under $SiteRoot." }
+
+$rel = $css.FullName.Substring($SiteRoot.Length).TrimStart('\','/')
+$linked = $false
+foreach ($h in $htmls) {
+  $c = Get-Content -Raw -Path $h.FullName
+  if ($c -match [Regex]::Escape($rel) -or $c -match [Regex]::Escape($css.Name)) { $linked = $true; break }
+}
+if (-not $linked) { throw "No HTML references '$($css.Name)' or '$rel'." }
+
+Write-Host "✅ CSS '$($css.Name)' exists and is referenced by at least one HTML."

--- a/build/Verify-CssLink.ps1
+++ b/build/Verify-CssLink.ps1
@@ -15,7 +15,7 @@ if ($css.Length -le 256) { throw "CSS '$($css.FullName)' appears too small to be
 $htmls = Get-ChildItem -Path $SiteRoot -Recurse -Include index.html,*.html
 if (-not $htmls) { throw "No HTML found under $SiteRoot." }
 
-$rel = $css.FullName.Substring($SiteRoot.Length).TrimStart('\','/')
+$rel = [System.IO.Path]::GetRelativePath($SiteRoot, $css.FullName)
 $linked = $false
 foreach ($h in $htmls) {
   $c = Get-Content -Raw -Path $h.FullName


### PR DESCRIPTION
## Summary
- restore the default layout CSS link tags to use the relative_url helper again
- add a Verify-CssLink.ps1 script that confirms CSS assets exist and are referenced in the generated site
- invoke the CSS verification step from azure-pipelines.yml so CI fails if the stylesheet is missing

## Testing
- bundle exec jekyll build --future


------
https://chatgpt.com/codex/tasks/task_e_68cdf881b7f8832d9666e5fe7975dec9