### PR TITLE
Fix CSS regression by restoring index layout and add pipeline validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ steps:
   displayName: 'List generated site contents'
 
 - powershell: |
-    $root = "$(Build.SourcesDirectory)\_site"
+    $root = "$(Build.SourcesDirectory)/_site"
     if (-not (Test-Path $root)) { throw "_site not found" }
     $css = Get-ChildItem $root -Recurse -Include *.css | Sort-Object Length -Descending | Select-Object -First 1
     if (-not $css -or $css.Length -lt 1024) { throw "CSS missing or too small" }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,8 +35,7 @@ steps:
     if (-not $css -or $css.Length -lt 1024) { throw "CSS missing or too small" }
     $name = $css.Name
     $html = Get-ChildItem $root -Recurse -Include *.html | Where-Object {
-      (Get-Content -Raw $_.FullName) -match [regex]::Escape($name) -or
-      (Get-Content -Raw $_.FullName) -match 'assets/main\.css'
+      Select-String -Path $_.FullName -Pattern ([regex]::Escape($name)), 'assets/main\.css' -Quiet
     } | Select-Object -First 1
     if (-not $html) { throw "No HTML references $name or assets/main.css" }
     Write-Host "✅ CSS present and referenced: $($css.FullName)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,8 +28,19 @@ steps:
 - script: ls -la _site
   displayName: 'List generated site contents'
 
-- script: pwsh -File build/Verify-CssLink.ps1 -SiteRoot "$(Build.SourcesDirectory)/_site" -CssHint "hyde.css"
-  displayName: 'Verify CSS linked in built site'
+- powershell: |
+    $root = "$(Build.SourcesDirectory)\_site"
+    if (-not (Test-Path $root)) { throw "_site not found" }
+    $css = Get-ChildItem $root -Recurse -Include *.css | Sort-Object Length -Descending | Select-Object -First 1
+    if (-not $css -or $css.Length -lt 1024) { throw "CSS missing or too small" }
+    $name = $css.Name
+    $html = Get-ChildItem $root -Recurse -Include *.html | Where-Object {
+      (Get-Content -Raw $_.FullName) -match [regex]::Escape($name) -or
+      (Get-Content -Raw $_.FullName) -match 'assets/main\.css'
+    } | Select-Object -First 1
+    if (-not $html) { throw "No HTML references $name or assets/main.css" }
+    Write-Host "✅ CSS present and referenced: $($css.FullName)"
+  displayName: "Verify CSS referenced in _site"
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish site artifact'

--- a/index.html
+++ b/index.html
@@ -1,4 +1,6 @@
 ---
+layout: default
+title: home
 header:
   teaser: /assets/menu/scripts-blog-intro.gif
 ---


### PR DESCRIPTION
## Summary
- restore the home page front matter so it uses the default layout that links the stylesheet bundle
- replace the ad-hoc CSS verification script call with an inline Azure Pipelines PowerShell check that enforces CSS presence and references

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68cdfebf486c832da1118242b234b7ea