### PR TITLE
Add faraday-retry dependency to fix build warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache"
 gem "webrick", "~> 1.8"
+gem "faraday-retry"
 
 group :jekyll_plugins do
   gem "jekyll-algolia"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -326,6 +328,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  faraday-retry
   github-pages
   jekyll-algolia
   jekyll-feed
@@ -336,3 +339,5 @@ DEPENDENCIES
   jekyll-sitemap
   webrick (~> 1.8)
 
+BUNDLED WITH
+   2.6.7


### PR DESCRIPTION
## Summary
- add the `faraday-retry` gem alongside the other top-level dependencies so Faraday retry middleware is available
- update `Gemfile.lock` to capture the resolved `faraday-retry` version and the Bundler version that generated the lockfile

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68ce09d90ad0832d90c31660547f1955