### PR TITLE
Explicitly declare Faraday dependencies for GitHub Pages build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache"
 gem "webrick", "~> 1.8"
-gem "faraday-retry"
+gem "faraday", "~> 2.13"
+gem "faraday-retry", "~> 2.3"
 
 group :jekyll_plugins do
   gem "jekyll-algolia"

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache"
 gem "webrick", "~> 1.8"
-gem "faraday", "~> 2.13"
-gem "faraday-retry", "~> 2.3"
+gem "faraday", "~> 2.0"
+gem "faraday-retry", "~> 2.0"
 
 group :jekyll_plugins do
   gem "jekyll-algolia"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  faraday-retry
+  faraday (~> 2.13)
+  faraday-retry (~> 2.3)
   github-pages
   jekyll-algolia
   jekyll-feed


### PR DESCRIPTION
## Summary
- add an explicit Faraday dependency alongside github-pages
- pin faraday-retry to the Faraday 2.x-compatible 2.3 series

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68ce0bd6c8bc832d85b6189898349016