### PR TITLE
Add GitHub Actions workflow for Jekyll builds

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -1,0 +1,41 @@
+name: Jekyll Build Validation
+
+on:
+  push:
+    branches: [prod]
+  pull_request:
+    branches: [prod]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_PATH: vendor/bundle
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Configure bundler path
+        run: bundle config set --local path 'vendor/bundle'
+
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Build site
+        run: bundle exec jekyll build --future
+
+      - name: Verify generated CSS is referenced
+        shell: pwsh
+        run: ./build/Verify-CssLink.ps1 -SiteRoot "_site" -CssHint "hyde.css"
+
+      - name: Upload built site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jekyll-site
+          path: _site

--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [prod]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs for pushes and pull requests targeting the publishing branch
- set up Ruby 3.1 with cached gems, install the bundle to `vendor/bundle`, and build the site with future-dated posts
- verify the generated CSS is referenced and upload the `_site` build output as an artifact

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce12c3b9ec832d94a1c11f3320a815