### PR TITLE
Require Jekyll build validation before auto-merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,7 @@ pull_request_rules:
     - name: Automatic merge on approval
       conditions:
         - "#approved-reviews-by>=1"
+        - "check-success=Jekyll Build Validation / build"
       actions:
         merge:
           method: merge


### PR DESCRIPTION
## Summary
- require the Jekyll Build Validation workflow to succeed before automatically merging approved pull requests

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce18c16548832dafa0524f8863dde4