### PR TITLE
Remove manual bundler setup from Jekyll workflow

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -23,12 +23,6 @@ jobs:
           ruby-version: '3.1'
           bundler-cache: true
 
-      - name: Configure bundler path
-        run: bundle config set --local path 'vendor/bundle'
-
-      - name: Install dependencies
-        run: bundle install --jobs 4 --retry 3
-
       - name: Build site
         run: bundle exec jekyll build --future
 


### PR DESCRIPTION
## Summary
- remove redundant bundler configuration and installation steps from the Jekyll build workflow
- rely on ruby/setup-ruby with bundler caching to provision dependencies automatically

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce1a7cea80832dbc970c8d479cb4b3