### PR TITLE
Add jekyll-seo-tag plugin configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,6 @@ group :jekyll_plugins do
   gem "jekyll-gist"
   gem "jekyll-json-feed"
   gem "jekyll-paginate"
+  gem "jekyll-seo-tag"
   gem "jekyll-sitemap"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -66,6 +66,7 @@ plugins:
   - jekyll-include-cache
   - jekyll-json-feed
   - jekyll-paginate
+  - jekyll-seo-tag
   - jekyll-sitemap
 
 github: [metadata]


### PR DESCRIPTION
## Summary
- add the jekyll-seo-tag gem to the plugin group
- enable the jekyll-seo-tag plugin in the Jekyll configuration

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68cf3409a4d0832d847132cd7d9dd6ad