### PR TITLE
Use jekyll-seo-tag in head include

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,87 +1,15 @@
 <head>
-  {% assign raw_description = page.description | default: page.excerpt | default: site.description %}
-  {% assign meta_description = raw_description | strip_html | replace: "\r\n", " " | replace: "\n", " " | replace: "\r", " " | replace: "  ", " " | strip | truncate: 160 %}
-  {% assign canonical_source = page.canonical_url | default: page.url %}
-  {% if canonical_source %}
-    {% if canonical_source contains '://' %}
-      {% assign canonical_url = canonical_source %}
-    {% else %}
-      {% assign canonical_url = canonical_source | relative_url | absolute_url %}
-    {% endif %}
-  {% endif %}
-  {% assign robots_content = page.robots | default: site.default_robots | default: "index,follow" %}
-  {% assign og_title = page.og_title | default: page.title | default: site.title %}
-  {% assign og_type = page.og_type %}
-  {% if og_type == nil %}
-    {% if page.collection == "posts" or page.layout == "post" %}
-      {% assign og_type = "article" %}
-    {% else %}
-      {% assign og_type = "website" %}
-    {% endif %}
-  {% endif %}
-  {% assign page_image = page.twitter_image | default: page.og_image | default: page.image | default: page.header.teaser | default: page.header.image | default: site.default_social_image %}
-  {% if page_image %}
-    {% if page_image contains '://' %}
-      {% assign meta_image = page_image %}
-    {% else %}
-      {% assign meta_image = page_image | relative_url | absolute_url %}
-    {% endif %}
-  {% endif %}
-  {% assign twitter_card = page.twitter_card | default: site.twitter_card %}
-  {% if twitter_card == nil %}
-    {% if meta_image %}
-      {% assign twitter_card = "summary_large_image" %}
-    {% else %}
-      {% assign twitter_card = "summary" %}
-    {% endif %}
-  {% endif %}
-  {% assign twitter_username = page.twitter_username | default: site.twitter_username %}
-  {% if twitter_username %}
-    {% if twitter_username contains '@' %}
-      {% assign twitter_handle = twitter_username %}
-    {% else %}
-      {% assign twitter_handle = '@' | append: twitter_username %}
-    {% endif %}
-  {% endif %}
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  {% seo %}
+  {% include structured-data.html %}
+
   <meta http-equiv="cache-control" content="public, max-age=604800, immutable">
   <meta name="keywords" content="PowerShell, Scripts, Functions, Snippets, Tools, Maintenance, Information Technology, Administration, Download, Automation, Learning">
-  {% if meta_description %}
-  <meta name="description" content="{{ meta_description | escape }}">
-  {% endif %}
-  {% if canonical_url %}
-  <link rel="canonical" href="{{ canonical_url | escape }}">
-  {% endif %}
+  {% assign robots_content = page.robots | default: site.default_robots | default: "index,follow" %}
   <meta name="robots" content="{{ robots_content }}">
-  <meta property="og:title" content="{{ og_title | escape }}">
-  {% if meta_description %}
-  <meta property="og:description" content="{{ meta_description | escape }}">
-  {% endif %}
-  <meta property="og:type" content="{{ og_type }}">
-  {% if canonical_url %}
-  <meta property="og:url" content="{{ canonical_url | escape }}">
-  {% endif %}
-  <meta property="og:site_name" content="{{ site.title | escape }}">
-  {% if meta_image %}
-  <meta property="og:image" content="{{ meta_image | escape }}">
-  {% endif %}
-  <meta name="twitter:card" content="{{ twitter_card }}">
-  <meta name="twitter:title" content="{{ og_title | escape }}">
-  {% if meta_description %}
-  <meta name="twitter:description" content="{{ meta_description | escape }}">
-  {% endif %}
-  {% if canonical_url %}
-  <meta name="twitter:url" content="{{ canonical_url | escape }}">
-  {% endif %}
-  {% if twitter_handle %}
-  <meta name="twitter:site" content="{{ twitter_handle }}">
-  <meta name="twitter:creator" content="{{ twitter_handle }}">
-  {% endif %}
-  {% if meta_image %}
-  <meta name="twitter:image" content="{{ meta_image | escape }}">
-  {% endif %}
 
   <!-- CSS -->
   <link rel="stylesheet" href="{{ "/assets/css/poole.css" | relative_url }}">
@@ -112,14 +40,6 @@
 
   <!-- site -->
   <script src="{{ "/assets/js/site.js" | relative_url }}"></script>
-
-  <title>
-    {% if page.title == "Home" %}
-      {{ site.title | escape }} &middot; {{ site.tagline | escape }}
-    {% else %}
-      {{ page.title | escape }} &middot; {{ site.title | escape }}
-    {% endif %}
-  </title>
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-3T94X6S0QF"></script>

--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -1,0 +1,3 @@
+{%- comment -%}
+  Placeholder for structured data JSON-LD. Content will be provided by future updates.
+{%- endcomment -%}


### PR DESCRIPTION
## Summary
- insert the `{% seo %}` tag near the top of the head include and remove redundant manual title/canonical/social meta markup
- keep custom metadata below the plugin output and load a new structured data partial immediately afterward

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68cf340dd658832db43414bfcee7b94f