### PR TITLE
ci: pin lychee action to v1

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check generated site links
         # Originally: lycheeverse/lychee-action@v1
-        uses: lycheeverse/lychee-action@c2e2e2b6e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2
+        uses: lycheeverse/lychee-action@v1
         with:
           args: >-
             --no-progress


### PR DESCRIPTION
## Summary
- update the Jekyll validation workflow to use the stable lychee action v1 reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf56c1a840832da2bfaf2693fb2332