### PR TITLE
Enforce SEO guardrail exit codes

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -45,15 +45,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run SEO guardrail checks
-        run: bundle exec ruby build/seo-checks.rb
+        run: |
+          ruby build/seo-checks.rb --site ./_site --out ./seo-checks.json
+        env:
+          CI: "true"
+          SEO_SOFT_FAIL_WARNINGS: "false"
+          SEO_SITEMAP_OPTIONAL: "false"
 
-      - name: Upload SEO reports
+      - name: Upload seo-checks.json
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: seo-reports
-          path: |
-            seo-checks.json
-            lychee-report.json
+          name: seo-checks
+          path: seo-checks.json
+
+      - name: Upload lychee report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report
+          path: lychee-report.json
 
       - name: Upload built site artifact
         uses: actions/upload-artifact@v4

--- a/build/seo-checks.rb
+++ b/build/seo-checks.rb
@@ -149,7 +149,6 @@ def canonical_local_path(site_dir, uri, site_url)
   return nil unless path
 
   normalized = path.empty? ? '/' : path
-  normalized = '/' if normalized == ''
   normalized = normalized.split('?').first
   normalized = '/' if normalized.nil? || normalized.empty?
   normalized = normalized.sub(%r{^/}, '')

--- a/build/seo-checks.rb
+++ b/build/seo-checks.rb
@@ -289,7 +289,7 @@ html_files.each do |html_path|
 
     if tag =~ /\bcontent\s*=\s*(['"])(.*?)\1/i
       robots_value = Regexp.last_match(2).downcase
-      if robots_value.include?('noindex') || robots_value.include?('none')
+      if robots_value.split(',').map(&:strip).any? { |directive| %w[noindex none].include?(directive) }
         noindex_flag = true
         noindex_pages_set.add(rel_path)
       end

--- a/build/seo-checks.rb
+++ b/build/seo-checks.rb
@@ -5,19 +5,52 @@ require 'json'
 require 'yaml'
 require 'time'
 require 'date'
-require 'webrick'
+require 'optparse'
 require 'net/http'
 require 'uri'
 require 'rexml/document'
 require 'rexml/xpath'
+require 'set'
 
 ROOT = File.expand_path('..', __dir__)
-SITE_DIR = File.expand_path('../_site', __dir__)
+DEFAULT_SITE_DIR = File.expand_path('../_site', __dir__)
+DEFAULT_OUT_PATH = File.join(ROOT, 'seo-checks.json')
+DEFAULT_ALLOWLIST_PATH = File.join(ROOT, 'build', 'seo-allowlist.yml')
 CONFIG_PATH = File.join(ROOT, '_config.yml')
 LYCHEE_PATH = File.join(ROOT, 'lychee-report.json')
-OUTPUT_PATH = File.join(ROOT, 'seo-checks.json')
 
-abort("Build directory not found: #{SITE_DIR}") unless Dir.exist?(SITE_DIR)
+options = {
+  site: DEFAULT_SITE_DIR,
+  out: DEFAULT_OUT_PATH,
+  allowlist: DEFAULT_ALLOWLIST_PATH
+}
+
+OptionParser.new do |opts|
+  opts.banner = 'Usage: seo-checks.rb [options]'
+
+  opts.on('--site PATH', 'Path to the built site directory (default: ./_site)') do |path|
+    options[:site] = path
+  end
+
+  opts.on('--out PATH', 'Output path for seo-checks.json (default: ./seo-checks.json)') do |path|
+    options[:out] = path
+  end
+
+  opts.on('--allowlist PATH', 'Path to allowlist YAML (default: ./build/seo-allowlist.yml)') do |path|
+    options[:allowlist] = path
+  end
+
+  opts.on('-h', '--help', 'Show this help message') do
+    puts opts
+    exit
+  end
+end.parse!(ARGV)
+
+site_dir = File.expand_path(options[:site])
+out_path = File.expand_path(options[:out])
+allowlist_path = options[:allowlist] && !options[:allowlist].empty? ? File.expand_path(options[:allowlist]) : nil
+
+abort("Build directory not found: #{site_dir}") unless Dir.exist?(site_dir)
 abort("Config file not found: #{CONFIG_PATH}") unless File.file?(CONFIG_PATH)
 
 config = YAML.safe_load(File.read(CONFIG_PATH), permitted_classes: [Date]) || {}
@@ -27,141 +60,450 @@ site_host = begin
 rescue URI::InvalidURIError
   nil
 end
-allowed_noindex = Array(config.dig('seo', 'noindex_allowlist')).map(&:to_s)
+allowed_noindex_patterns = Array(config.dig('seo', 'noindex_allowlist')).map(&:to_s)
 
+soft_fail_warnings = ENV.fetch('SEO_SOFT_FAIL_WARNINGS', 'false').to_s.downcase == 'true'
+sitemap_optional = ENV.fetch('SEO_SITEMAP_OPTIONAL', 'false').to_s.downcase == 'true'
+ci_environment = ENV.fetch('CI', nil)
+
+allowlist_patterns = []
+allowlist_warning = nil
+if allowlist_path && File.exist?(allowlist_path)
+  begin
+    raw_allowlist = YAML.safe_load(File.read(allowlist_path))
+    allowlist_patterns =
+      case raw_allowlist
+      when Array
+        raw_allowlist
+      when Hash
+        raw_allowlist.values.flatten
+      else
+        []
+      end
+    allowlist_patterns = Array(allowlist_patterns).compact.map(&:to_s)
+  rescue StandardError => e
+    allowlist_warning = "Failed to load allowlist #{allowlist_path}: #{e.message}"
+  end
+end
+
+FNM_FLAGS = File::FNM_CASEFOLD | File::FNM_PATHNAME | (defined?(File::FNM_EXTGLOB) ? File::FNM_EXTGLOB : 0)
+
+def allowlisted?(patterns, candidate)
+  return false if candidate.nil?
+
+  value_str = candidate.to_s
+  values = [value_str]
+  values << value_str.delete_prefix('/') if value_str.start_with?('/')
+  values << "/#{value_str}" unless value_str.start_with?('/')
+  values.uniq.any? do |value|
+    patterns.any? do |pattern|
+      next false if pattern.nil?
+
+      pattern_str = pattern.to_s
+      match = begin
+        File.fnmatch?(pattern_str, value, FNM_FLAGS)
+      rescue ArgumentError
+        false
+      end
+      match || (!pattern_str.empty? && value.include?(pattern_str))
+    end
+  end
+end
+
+def http_get_with_retries(uri, attempts: 3, open_timeout: 5, read_timeout: 10)
+  last_error = nil
+  attempts.times do |attempt|
+    begin
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', open_timeout: open_timeout, read_timeout: read_timeout) do |http|
+        request_uri = uri.request_uri
+        request_uri = '/' if request_uri.nil? || request_uri.empty?
+        response = http.request(Net::HTTP::Get.new(request_uri))
+        return response
+      end
+    rescue StandardError => e
+      last_error = e
+      sleep(0.5 * (attempt + 1)) if attempt < attempts - 1
+    end
+  end
+  raise last_error if last_error
+end
+
+def canonical_local_path(site_dir, uri, site_url)
+  return nil unless uri
+
+  site_uri = begin
+    URI(site_url) if site_url
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  path =
+    if uri.scheme.nil? || uri.host.nil?
+      uri.path
+    elsif site_uri && uri.host == site_uri.host
+      uri.path
+    else
+      nil
+    end
+
+  return nil unless path
+
+  normalized = path.empty? ? '/' : path
+  normalized = '/' if normalized == ''
+  normalized = normalized.split('?').first
+  normalized = '/' if normalized.nil? || normalized.empty?
+  normalized = normalized.sub(%r{^/}, '')
+
+  candidates = []
+  if normalized.empty?
+    candidates << 'index.html'
+  else
+    candidates << normalized
+    unless normalized.end_with?('.html')
+      candidates << File.join(normalized, 'index.html')
+      candidates << "#{normalized}.html" unless normalized.include?('.')
+    end
+  end
+
+  candidates.each do |relative|
+    candidate_path = File.join(site_dir, relative)
+    return candidate_path if File.file?(candidate_path)
+  end
+
+  nil
+end
+
+warning_entries = []
+warning_seen = Set.new
 warnings = []
+missing_canonical_set = Set.new
+non_200_canonical_entries = []
+non_200_seen = Set.new
+missing_sitemap_entries = []
+missing_sitemap_seen = Set.new
+unexpected_noindex_set = Set.new
+canonical_checks = []
+noindex_pages_set = Set.new
+refresh_pages_set = Set.new
 
-sitemap_path = File.join(SITE_DIR, 'sitemap.xml')
+if allowlist_warning
+  warning_key = [nil, allowlist_warning]
+  warning_entries << { 'message' => allowlist_warning }
+  warning_seen.add(warning_key)
+  warnings << allowlist_warning
+  puts "::warning ::SEO: #{allowlist_warning}"
+end
+
+sitemap_path = File.join(site_dir, 'sitemap.xml')
 sitemap_present = File.file?(sitemap_path)
 sitemap_urls = []
+
 if sitemap_present
   begin
     xml = REXML::Document.new(File.read(sitemap_path))
     REXML::XPath.each(xml, '//url/loc') do |loc|
-      sitemap_urls << loc.text.strip
+      sitemap_urls << loc.text.to_s.strip
     end
   rescue StandardError => e
-    warnings << "Failed to parse sitemap.xml: #{e.message}"
+    message = "Failed to parse sitemap.xml: #{e.message}"
+    warning_key = [nil, message]
+    unless warning_seen.include?(warning_key)
+      warning_entries << { 'message' => message }
+      warning_seen.add(warning_key)
+    end
+    warnings << message unless warnings.include?(message)
+    puts "::warning ::SEO: #{message}"
   end
 else
-  warnings << 'sitemap.xml is missing from the build output'
+  message = "sitemap.xml is missing from #{site_dir}"
+  missing_key = [nil, message]
+  unless missing_sitemap_seen.include?(missing_key)
+    missing_sitemap_entries << { 'message' => message }
+    missing_sitemap_seen.add(missing_key)
+  end
+
+  if sitemap_optional
+    warning_key = [nil, message]
+    unless warning_seen.include?(warning_key)
+      warning_entries << { 'message' => message }
+      warning_seen.add(warning_key)
+    end
+    warnings << message unless warnings.include?(message)
+    puts "::warning ::SEO: #{message}"
+  else
+    puts "::error ::SEO: #{message}"
+  end
 end
 
-html_files = Dir.glob(File.join(SITE_DIR, '**', '*.html'))
+remote_sitemap_status = nil
+remote_sitemap_error = nil
+if !sitemap_present && site_url
+  begin
+    sitemap_uri = URI.join(site_url, '/sitemap.xml')
+    response = http_get_with_retries(sitemap_uri, attempts: 2)
+    remote_sitemap_status = response.code.to_i
+    if remote_sitemap_status && remote_sitemap_status >= 400
+      message = "Remote sitemap returned #{remote_sitemap_status}"
+      warning_key = [nil, message]
+      unless warning_seen.include?(warning_key)
+        warning_entries << { 'message' => message }
+        warning_seen.add(warning_key)
+      end
+      warnings << message unless warnings.include?(message)
+      puts "::warning ::SEO: #{message}"
+    end
+  rescue StandardError => e
+    remote_sitemap_error = e.message
+    message = "Failed to fetch remote sitemap: #{e.message}"
+    warning_key = [nil, message]
+    unless warning_seen.include?(warning_key)
+      warning_entries << { 'message' => message }
+      warning_seen.add(warning_key)
+    end
+    warnings << message unless warnings.include?(message)
+    puts "::warning ::SEO: #{message}"
+  end
+end
+
+html_files = Dir.glob(File.join(site_dir, '**', '*.html')).sort
 canonical_map = {}
-missing_canonicals = []
-noindex_pages = []
-refresh_pages = []
 
 html_files.each do |html_path|
-  rel_path = html_path.delete_prefix(SITE_DIR + '/').sub(%r{^/}, '')
+  rel_path = html_path.delete_prefix(site_dir + '/').sub(%r{^/}, '')
+  allowlisted_page = allowlisted?(allowlist_patterns, rel_path)
+
   content = File.read(html_path, encoding: 'UTF-8', invalid: :replace, undef: :replace, replace: '')
 
   canonical_url = nil
-  # Find all <link ...> tags, then check for rel="canonical" and extract href
-  link_tags = content.scan(/<link[^>]*>/i)
-  tag = link_tags.find { |t| t =~ /\brel=['"]canonical['"]/i }
-  if tag && tag =~ /\bhref=['"]([^'"]+)['"]/i
-    canonical_url = $1.strip
+  content.scan(/<link[^>]*>/i).each do |tag|
+    next unless tag =~ /\brel\s*=\s*['"]canonical['"]/i
+
+    if tag =~ /\bhref\s*=\s*['"]([^'"]+)['"]/i
+      canonical_url = Regexp.last_match(1).strip
+      break
+    end
   end
 
   noindex_flag = false
-  # Find all <meta ...> tags
-  meta_tags = content.scan(/<meta[^>]*>/i)
-  meta_tags.each do |tag|
-    # Check if this meta tag is for robots
-    if tag =~ /\bname\s*=\s*(['"])robots\1/i
-      # Extract the content attribute value
-      if tag =~ /\bcontent\s*=\s*(['"])(.*?)\1/i
-        robots_value = Regexp.last_match(2).downcase
-        if robots_value.include?('noindex')
-          noindex_flag = true
-          noindex_pages << rel_path
-        end
+  content.scan(/<meta[^>]*>/i).each do |tag|
+    next unless tag =~ /\bname\s*=\s*(['"])robots\1/i
+
+    if tag =~ /\bcontent\s*=\s*(['"])(.*?)\1/i
+      robots_value = Regexp.last_match(2).downcase
+      if robots_value.include?('noindex') || robots_value.include?('none')
+        noindex_flag = true
+        noindex_pages_set.add(rel_path)
       end
     end
   end
 
   if canonical_url
     canonical_map[rel_path] = canonical_url
-  elsif !noindex_flag
-    missing_canonicals << rel_path
+  elsif !noindex_flag && !allowlisted_page
+    missing_canonical_set.add(rel_path)
+    puts "::warning file=#{rel_path},line=1,col=1::SEO: Missing canonical link"
   end
 
-  refresh_pages << rel_path if content =~ /http-equiv=(['"])refresh\1/i
+  refresh_pages_set.add(rel_path) if content =~ /http-equiv\s*=\s*(['"])refresh\1/i
 end
 
-server = WEBrick::HTTPServer.new(
-  Port: 4123,
-  DocumentRoot: SITE_DIR,
-  AccessLog: [],
-  Logger: WEBrick::Log.new($stderr, WEBrick::Log::WARN)
-)
+canonical_map.each do |rel_path, canonical_url|
+  allowlisted_page = allowlisted?(allowlist_patterns, rel_path)
+  allowlisted_canonical = allowlisted?(allowlist_patterns, canonical_url)
+  canonical_entry = {
+    'file' => rel_path,
+    'canonical' => canonical_url
+  }
 
-canonical_checks = []
-server_thread = nil
+  begin
+    uri = URI.parse(canonical_url)
+  rescue URI::InvalidURIError
+    canonical_entry['http_status'] = nil
+    canonical_entry['error'] = 'invalid canonical URL'
+    canonical_checks << canonical_entry
 
-begin
-  server_thread = Thread.new { server.start }
-  sleep 0.5
+    unless allowlisted_page || allowlisted_canonical
+      message = "Invalid canonical URL for #{rel_path}: #{canonical_url}"
+      warning_key = [rel_path, message]
+      unless warning_seen.include?(warning_key)
+        warning_entries << { 'file' => rel_path, 'message' => message }
+        warning_seen.add(warning_key)
+      end
+      warnings << message unless warnings.include?(message)
+      puts "::warning file=#{rel_path},line=1,col=1::SEO: Invalid canonical URL #{canonical_url}"
+    end
+    next
+  end
 
-  http = Net::HTTP.new('127.0.0.1', server.config[:Port])
-  http.read_timeout = 10
-  http.open_timeout = 5
+  local_target = canonical_local_path(site_dir, uri, site_url)
 
-  canonical_map.each do |rel_path, canonical_url|
-    begin
-      uri = URI.parse(canonical_url)
-    rescue URI::InvalidURIError
-      canonical_checks << {
-        'file' => rel_path,
+  if site_host && uri.host && uri.host != site_host && !allowlisted_page && !allowlisted_canonical
+    message = "Canonical host mismatch for #{rel_path}: #{canonical_url}"
+    warning_key = [rel_path, message]
+    unless warning_seen.include?(warning_key)
+      warning_entries << { 'file' => rel_path, 'message' => message }
+      warning_seen.add(warning_key)
+    end
+    warnings << message unless warnings.include?(message)
+    puts "::warning file=#{rel_path},line=1,col=1::SEO: Canonical host mismatch #{canonical_url}"
+  end
+
+  if local_target
+    canonical_entry['http_status'] = 200
+    canonical_checks << canonical_entry
+    next
+  end
+
+  if uri.host.nil? && !uri.path.to_s.empty? && ci_environment
+    # Relative canonical that doesn't map to a local file in CI is a potential issue.
+    canonical_entry['http_status'] = nil
+    canonical_entry['error'] = 'canonical target missing from local build'
+    canonical_checks << canonical_entry
+
+    unless allowlisted_page || allowlisted_canonical
+      detail = {
+        'page' => rel_path,
         'canonical' => canonical_url,
-        'http_status' => nil,
-        'error' => 'invalid canonical URL'
+        'error' => 'canonical target missing from local build'
       }
+      detail_key = [rel_path, canonical_url, 'missing_local']
+      unless non_200_seen.include?(detail_key)
+        non_200_seen.add(detail_key)
+        non_200_canonical_entries << detail
+      end
+      puts "::error file=#{rel_path},line=1,col=1::SEO: Canonical #{canonical_url} not found in local build"
+    end
+    next
+  end
+
+  if uri.host.nil?
+    # Attempt to build an absolute URI using site_url if possible.
+    begin
+      site_uri = URI(site_url) if site_url
+    rescue URI::InvalidURIError
+      site_uri = nil
+    end
+    if site_uri
+      uri = site_uri.merge(canonical_url)
+    else
+      canonical_entry['http_status'] = nil
+      canonical_entry['error'] = 'unable to resolve canonical host'
+      canonical_checks << canonical_entry
+
+      unless allowlisted_page || allowlisted_canonical
+        detail = {
+          'page' => rel_path,
+          'canonical' => canonical_url,
+          'error' => 'unable to resolve canonical host'
+        }
+        detail_key = [rel_path, canonical_url, 'resolve_host']
+        unless non_200_seen.include?(detail_key)
+          non_200_seen.add(detail_key)
+          non_200_canonical_entries << detail
+        end
+        puts "::error file=#{rel_path},line=1,col=1::SEO: Unable to resolve canonical host for #{canonical_url}"
+      end
       next
     end
+  end
 
-    if site_host && uri.host && uri.host != site_host
-      warnings << "Canonical host mismatch for #{rel_path}: #{canonical_url}"
+  begin
+    response = http_get_with_retries(uri)
+    canonical_entry['http_status'] = response.code.to_i
+    canonical_checks << canonical_entry
+
+    next if response.code.to_i.between?(200, 299)
+
+    unless allowlisted_page || allowlisted_canonical
+      detail = {
+        'page' => rel_path,
+        'canonical' => canonical_url,
+        'status' => response.code.to_i
+      }
+      detail_key = [rel_path, canonical_url, response.code.to_i]
+      unless non_200_seen.include?(detail_key)
+        non_200_seen.add(detail_key)
+        non_200_canonical_entries << detail
+      end
+      puts "::error file=#{rel_path},line=1,col=1::SEO: Canonical #{canonical_url} returned #{response.code}"
     end
+  rescue StandardError => e
+    canonical_entry['http_status'] = nil
+    canonical_entry['error'] = e.message
+    canonical_checks << canonical_entry
 
-    request_path = uri.path.to_s
-    request_path = '/' if request_path.empty?
-    request_path += "?#{uri.query}" if uri.query
-
-    begin
-      response = http.get(request_path)
-      canonical_checks << {
-        'file' => rel_path,
+    unless allowlisted_page || allowlisted_canonical
+      detail = {
+        'page' => rel_path,
         'canonical' => canonical_url,
-        'http_status' => response.code.to_i
+        'error' => e.class.to_s
       }
-    rescue StandardError => e
-      canonical_checks << {
-        'file' => rel_path,
-        'canonical' => canonical_url,
-        'http_status' => nil,
-        'error' => e.message
-      }
+      detail_key = [rel_path, canonical_url, e.class.to_s]
+      unless non_200_seen.include?(detail_key)
+        non_200_seen.add(detail_key)
+        non_200_canonical_entries << detail
+      end
+      puts "::error file=#{rel_path},line=1,col=1::SEO: Canonical #{canonical_url} request failed (#{e.class})"
     end
   end
-ensure
-  server.shutdown
-  server_thread&.join
 end
+
+unique_noindex = noindex_pages_set.to_a.sort
+
+unexpected_noindex = unique_noindex.reject do |path|
+  allowlisted?(allowlist_patterns, path) || allowlisted?(allowed_noindex_patterns, path)
+end
+
+unexpected_noindex.each do |path|
+  unexpected_noindex_set.add(path)
+  puts "::error file=#{path},line=1,col=1::SEO: Unexpected noindex"
+end
+
+refresh_pages = refresh_pages_set.to_a.sort
+missing_canonicals = missing_canonical_set.to_a.sort
+non_200_canonicals = non_200_canonical_entries
+missing_sitemap = missing_sitemap_entries
+unexpected_noindex_list = unexpected_noindex_set.to_a.sort
+
+warning_entries.uniq!
+
+counts = {
+  warnings: warning_entries.length,
+  missing_canonicals: missing_canonicals.length,
+  non_200_canonicals: non_200_canonicals.length,
+  missing_sitemap: missing_sitemap.length,
+  unexpected_noindex: unexpected_noindex_list.length
+}
+
+items = {
+  warnings: warning_entries,
+  missing_canonicals: missing_canonicals,
+  non_200_canonicals: non_200_canonicals,
+  missing_sitemap: missing_sitemap,
+  unexpected_noindex: unexpected_noindex_list
+}
+
+if counts[:missing_canonicals].positive?
+  warnings.concat(missing_canonicals.map { |path| "Missing canonical for #{path}" })
+end
+
+warnings.uniq!
 
 lychee_report = nil
 if File.file?(LYCHEE_PATH)
   begin
     lychee_report = JSON.parse(File.read(LYCHEE_PATH))
   rescue StandardError => e
-    warnings << "Failed to parse lychee report: #{e.message}"
+    message = "Failed to parse lychee report: #{e.message}"
+    warning_key = [nil, message]
+    unless warning_seen.include?(warning_key)
+      warning_entries << { 'message' => message }
+      warning_seen.add(warning_key)
+    end
+    warnings << message unless warnings.include?(message)
+    puts "::warning ::SEO: #{message}"
   end
 end
-
-unique_noindex = noindex_pages.uniq.sort
-unexpected_noindex = unique_noindex - allowed_noindex
 
 results = {
   'generated_at' => Time.now.utc.iso8601,
@@ -169,15 +511,34 @@ results = {
   'sitemap_present' => sitemap_present,
   'sitemap_url_count' => sitemap_urls.length,
   'sitemap_urls' => sitemap_urls,
+  'remote_sitemap_status' => remote_sitemap_status,
+  'remote_sitemap_error' => remote_sitemap_error,
   'pages_scanned' => html_files.length,
-  'missing_canonicals' => missing_canonicals.sort,
+  'missing_canonicals' => missing_canonicals,
   'canonical_checks' => canonical_checks,
   'noindex_pages' => unique_noindex,
-  'unexpected_noindex' => unexpected_noindex,
-  'meta_refresh_pages' => refresh_pages.uniq.sort,
+  'unexpected_noindex' => unexpected_noindex_list,
+  'meta_refresh_pages' => refresh_pages,
   'lychee_report' => lychee_report,
-  'warnings' => warnings.uniq
+  'warnings' => warnings,
+  'counts' => counts,
+  'items' => items
 }
 
-File.write(OUTPUT_PATH, JSON.pretty_generate(results))
-puts "SEO checks written to #{OUTPUT_PATH}"
+File.write(out_path, JSON.pretty_generate(results))
+puts "SEO checks written to #{out_path}"
+
+critical_missing_sitemap = counts[:missing_sitemap].positive? && !sitemap_optional
+critical_violations = critical_missing_sitemap || counts[:non_200_canonicals].positive? || counts[:unexpected_noindex].positive?
+warning_violations = counts[:warnings].positive? || counts[:missing_canonicals].positive?
+
+exit_code =
+  if critical_violations
+    3
+  elsif warning_violations
+    soft_fail_warnings ? 0 : 2
+  else
+    0
+  end
+
+exit exit_code

--- a/build/seo-checks.rb
+++ b/build/seo-checks.rb
@@ -464,7 +464,17 @@ non_200_canonicals = non_200_canonical_entries
 missing_sitemap = missing_sitemap_entries
 unexpected_noindex_list = unexpected_noindex_set.to_a.sort
 
-warning_entries.uniq!
+# Deduplicate warning_entries by message content
+seen_messages = Set.new
+warning_entries.select! do |entry|
+  msg = entry['message'] || entry[:message]
+  if seen_messages.include?(msg)
+    false
+  else
+    seen_messages.add(msg)
+    true
+  end
+end
 
 counts = {
   warnings: warning_entries.length,


### PR DESCRIPTION
## Summary
- expand `build/seo-checks.rb` with CLI options, allowlist handling, GitHub annotation output, and severity-based exit codes
- record violation counts/details in `seo-checks.json` while continuing to capture sitemap, canonical, and noindex diagnostics
- run the guardrail script in CI with explicit environment toggles and always upload the generated reports

## Testing
- bundle exec jekyll build --future
- CI=true SEO_SOFT_FAIL_WARNINGS=false SEO_SITEMAP_OPTIONAL=false ruby build/seo-checks.rb --site ./_site --out ./seo-checks.json

------
https://chatgpt.com/codex/tasks/task_e_68cf5f9a7714832db11f997cc912eb3c