### PR TITLE
Add PowerShell 7 requirement to public functions

### DIFF
--- a/PowerShell/UserAdminModule/PKICertificateTools/Public/Get-RDGCAIssuedCert.ps1
+++ b/PowerShell/UserAdminModule/PKICertificateTools/Public/Get-RDGCAIssuedCert.ps1
@@ -46,6 +46,8 @@
 .NOTES
     Requires the PSPKI module to be installed and network access to the target CAs.
 #>
+#requires -Version 7.0
+#requires -PSEdition Core
 function Get-RDGCAIssuedCert {
     [CmdletBinding(DefaultParameterSetName = 'All')]
     [OutputType([PSCustomObject])]

--- a/PowerShell/UserAdminModule/PKICertificateTools/Public/Get-RDGCARequestPending.ps1
+++ b/PowerShell/UserAdminModule/PKICertificateTools/Public/Get-RDGCARequestPending.ps1
@@ -47,6 +47,8 @@
 .NOTES
     Requires the PSPKI module to be installed and network access to the target CAs.
 #>
+#requires -Version 7.0
+#requires -PSEdition Core
 function Get-RDGCARequestPending {
     [CmdletBinding()]
     [OutputType([PSCustomObject])]

--- a/PowerShell/UserAdminModule/Utilities/Public/Invoke-WithPsGalleryStats.ps1
+++ b/PowerShell/UserAdminModule/Utilities/Public/Invoke-WithPsGalleryStats.ps1
@@ -32,6 +32,8 @@
     .EXAMPLE
     Fuck-WithPsGalleryStats -ModuleNames @('Transmission', 'JsonToPowershellClass') -DownloadCount 99 -MinIntervalSeconds 10 -MaxIntervalSeconds 120
 #>
+#requires -Version 7.0
+#requires -PSEdition Core
 function Invoke-WithPsGalleryStats {
     [CmdletBinding()]
     param (


### PR DESCRIPTION
## Summary
- add PowerShell 7 Core requirements to Invoke-WithPsGalleryStats
- add PowerShell 7 Core requirements to Get-RDGCAIssuedCert and Get-RDGCARequestPending

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ed131aa4832db24bee6d0db30b38