### PR TITLE
Add Desktop edition requirement to AD functions

### DIFF
--- a/PowerShell/UserAdminModule/ADFunctions/Public/ADUserAccountFunctions.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/ADUserAccountFunctions.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-ADUserPassword {
 	
 	Set-ADAccountPassword -Identity $User.text -NewPassword (ConvertTo-SecureString -AsPlainText $Password.text -Force)

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Add-ADUsertoLocalGroup.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Add-ADUsertoLocalGroup.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Add-ADUsertoLocalGroup {
     [CmdletBinding(DefaultParameterSetName = 'Default',
         HelpURI = 'https://scripts.lukeleigh.com/useradminmodule/adfunctions/add-adusertolocalgroup/')]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Amend-pwdLastSet.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Amend-pwdLastSet.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-PasswordLastSetDate {
     [CmdletBinding(SupportsShouldProcess = $false)]
     param (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Compare-GroupMembership.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Compare-GroupMembership.ps1
@@ -20,6 +20,7 @@
         Author: Your Name
         Date:   Today's Date
 #>
+#requires -PSEdition Desktop
 
 function Compare-GroupMembership {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Copy-AdGroupMemberShip.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Copy-AdGroupMemberShip.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Copy-AdGroupMemberShip {
 
     <#  

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Copy-GroupMembership.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Copy-GroupMembership.ps1
@@ -26,6 +26,7 @@
     Author: Your Name
     Date: Today's Date
 #>
+#requires -PSEdition Desktop
 
 function Copy-GroupMembership {
     [CmdletBinding(SupportsShouldProcess = $true)]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Disable-InactiveComputer.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Disable-InactiveComputer.ps1
@@ -25,6 +25,7 @@
     Author: Your Name
     Date: Today's Date
 #>
+#requires -PSEdition Desktop
 
 Function Disable-InactiveComputer {
     [CmdletBinding(SupportsShouldProcess = $true)]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/DisableADAccountsMenu.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/DisableADAccountsMenu.ps1
@@ -1,4 +1,5 @@
 #requires -Modules PSMenu
+#requires -PSEdition Desktop
 
 <#
 .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/FSMOFunctions.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/FSMOFunctions.ps1
@@ -110,6 +110,7 @@
     https://github.com/BanterBoy/scripts-blog
 
 #>
+#requires -PSEdition Desktop
 
 #Requires -Module ActiveDirectory
 #Requires -RunAsAdministrator

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Find-UnusedADAccounts.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Find-UnusedADAccounts.ps1
@@ -37,6 +37,7 @@
     This function requires the Active Directory module to be installed.
 
 #>
+#requires -PSEdition Desktop
 
 function Find-UnusedADAccounts {
     

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Find-localAdmins.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Find-localAdmins.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Find-localAdmins {
 
 	<#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADComputerSearch.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADComputerSearch.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ADComputerSearch {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADDeletedUsers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADDeletedUsers.ps1
@@ -5,6 +5,7 @@
     .EXAMPLE
     Get-ADDeletedUsers -domainprefix example -domainsuffix local
 #>
+#requires -PSEdition Desktop
 
 Function Get-ADDeletedUsers {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADDiagnosticConfiguration.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADDiagnosticConfiguration.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ADDiagnosticConfiguration {
     <#
         .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADDiagnosticLogging.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADDiagnosticLogging.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ADDiagnosticLogging {
     param (
         [Parameter(Mandatory = $true)]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADEmailAddress.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADEmailAddress.ps1
@@ -31,6 +31,7 @@ Version: 1.0
 https://link-to-documentation
 
 #>
+#requires -PSEdition Desktop
 function Get-ADEmailAddress {
     [CmdletBinding(
         SupportsShouldProcess = $true,

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADGroupAccountDetails.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADGroupAccountDetails.ps1
@@ -35,6 +35,7 @@ This function requires the Active Directory module to be installed. Make sure yo
 https://docs.microsoft.com/en-us/powershell/module/activedirectory
 
 #>
+#requires -PSEdition Desktop
 
 function Get-ADGroupAccountDetails {
     [CmdletBinding(

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADGroupMembers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADGroupMembers.ps1
@@ -22,6 +22,7 @@
 .INPUTS
     [string]GroupName
 #>
+#requires -PSEdition Desktop
 function Get-ADGroupMembers {
     [CmdletBinding(DefaultParameterSetName = 'Default',
         PositionalBinding = $true,

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADGroupNames.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADGroupNames.ps1
@@ -27,6 +27,7 @@
     Author: Your Name
     Date:   Today's date
 #>
+#requires -PSEdition Desktop
 function Get-ADGroupNames {
     [CmdletBinding(DefaultParameterSetName = 'Default',
         PositionalBinding = $true,

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADObjectAddress.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADObjectAddress.ps1
@@ -36,6 +36,7 @@ This function requires the Active Directory module to be installed. If the modul
 https://docs.microsoft.com/en-us/powershell/module/addsadministration/get-adobject
 
 #>
+#requires -PSEdition Desktop
 
 function Get-ADObjectAddress {
     [CmdletBinding(

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADPasswordReminderUsers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADPasswordReminderUsers.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ADPasswordReminderUsers {
 	<#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserAudit.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserAudit.ps1
@@ -1,5 +1,6 @@
 #requires -version 5.1
 #requires -module ActiveDirectory
+#requires -PSEdition Desktop
 
 #you might need to increase the size of the Security eventlog
 # limit-eventlog -LogName security -ComputerName dom2,dom1 -MaximumSize 1024MB

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserEmailProperties.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserEmailProperties.ps1
@@ -30,6 +30,7 @@ https://docs.microsoft.com/en-us/powershell/module/activedirectory/get-aduser
 https://docs.microsoft.com/en-us/powershell/module/exchange/get-mailbox
 
 #>
+#requires -PSEdition Desktop
 
 function Get-ADUserEmailProperties {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserExchangeDN.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserExchangeDN.ps1
@@ -24,6 +24,7 @@ This function requires the Active Directory module to be installed. Make sure yo
 .LINK
 Get-ADUser
 #>
+#requires -PSEdition Desktop
 
 function Get-ADUserExchangeDN {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserLastLogon.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserLastLogon.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 Import-Module ActiveDirectory
 
 function Get-ADUserLastLogon([string]$userName) {

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserSearch.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserSearch.ps1
@@ -63,6 +63,7 @@
     https://link-to-your-documentation
 
 #>
+#requires -PSEdition Desktop
 
 function Get-ADUserSearch {
     [CmdletBinding(

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserSearch2.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ADUserSearch2.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ADUserSearch2 {
     [CmdletBinding(
         SupportsShouldProcess = $true,

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ActiveDirectoryTombstonePeriod.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ActiveDirectoryTombstonePeriod.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ActiveDirectoryTombstonePeriod {
   <#
   

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-AdminGroupsWithComputers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-AdminGroupsWithComputers.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-AdminGroupsWithComputers {
 <#
 .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-AllDomainControllers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-AllDomainControllers.ps1
@@ -25,6 +25,7 @@ Author: Your Name
 Date: Current Date
 Version: 1.0
 #>
+#requires -PSEdition Desktop
 
 Function Get-AllDomainControllers {
     Get-ADDomainController -Filter * -Server (Get-ADDomain).DNSRoot | Select-Object Hostname,Site,OperatingSystem

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-Cert.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-Cert.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-Cert {
   param (
     [string]$filter,

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ComputersWithoutBitLocker.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ComputersWithoutBitLocker.ps1
@@ -45,6 +45,7 @@
         - Notes: Additional information (e.g., "No BitLocker recovery information found").
 
 #>
+#requires -PSEdition Desktop
 
 function Get-ComputersWithoutBitLocker {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-CurrentUserLogon.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-CurrentUserLogon.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-CurrentUserLogon {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-DirectReports.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-DirectReports.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-DirectReports {
 
 	<#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-DomainControllers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-DomainControllers.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-DomainControllers {
     [CmdletBinding()]
     Param(

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ElevatedUsers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ElevatedUsers.ps1
@@ -1,5 +1,6 @@
 # PowerShell function to list users in Authoritative Groups in Active Directory
 # http://jeffwouters.nl/index.php/2013/11/powershell-function-to-list-users-in-authorative-groups-in-active-directory/
+#requires -PSEdition Desktop
 
 # Import the Modules
 Import-Module ActiveDirectory

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-EmptyOUs.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-EmptyOUs.ps1
@@ -27,6 +27,7 @@
 .NOTES
     This function requires the Active Directory module to be installed. It should be run with appropriate permissions to manage OUs in Active Directory.
 #>
+#requires -PSEdition Desktop
 
 function Get-EmptyOUs {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-FSMORoleOwner.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-FSMORoleOwner.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-FSMORoleOwner {
 
     <#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-FeaturesInventory.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-FeaturesInventory.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 Function Get-FeaturesInventory {
 	<#
 		.SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-GPProcessingTime.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-GPProcessingTime.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-GPProcessingtime {
     <#
     .Synopsis

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-LapsAndBitLocker.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-LapsAndBitLocker.ps1
@@ -50,6 +50,7 @@ Returns a custom object with the following properties:
 .LINK
 https://learn.microsoft.com/en-us/powershell/module/activedirectory/
 #>
+#requires -PSEdition Desktop
 
 function Get-LapsAndBitLocker {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-LastGPOUpdateTime.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-LastGPOUpdateTime.ps1
@@ -28,6 +28,7 @@ Author: Your Name
 Date: Today's Date
 Version: 1.0
 #>
+#requires -PSEdition Desktop
 function Get-LastGPOUpdateTime {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-LocalGroupMembership.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-LocalGroupMembership.ps1
@@ -17,6 +17,7 @@
 #                ComputerName Parameter now accept multiple computers
 #
 # ############################################################################# 
+#requires -PSEdition Desktop
 
 Function Get-LocalGroupMembership {
     <#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-LockoutHistory.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-LockoutHistory.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-LockoutHistory {
 
 	<#  

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-LoggedOnUser.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-LoggedOnUser.ps1
@@ -15,6 +15,7 @@ function Get-LoggedOnUser {
 }
 
 #>
+#requires -PSEdition Desktop
 function Get-LoggedOnUser {
     [CmdletBinding()]
     param

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-LogonEvents.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-LogonEvents.ps1
@@ -17,6 +17,7 @@
     Author: Your Name
     Date: Today's Date
 #>
+#requires -PSEdition Desktop
 
 function Get-LogonEvents {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-LogonHistory.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-LogonHistory.ps1
@@ -26,6 +26,7 @@ System.Management.Automation.PSObject
 Author: Your Name
 Date:   Current Date
 #>
+#requires -PSEdition Desktop
 
 function Get-LogonHistory {
     Param (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-NestedGroupMember.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-NestedGroupMember.ps1
@@ -6,6 +6,7 @@ Notes         : Find all members in the group specified
                 If any member in that group is another group call this function again
                 otherwise, output the non-group object
 #>
+#requires -PSEdition Desktop
 
 function Get-NestedGroupMember {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-O365LastLogonTime.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-O365LastLogonTime.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-O365LastLogonTime {
 
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-OUDelegations.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-OUDelegations.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-OUDelegations {
 
     <#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-RemoteServiceAccount.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-RemoteServiceAccount.ps1
@@ -6,6 +6,7 @@
         Where-Object { $_.DisplayName -like "backup exec*" }
     }
 #>
+#requires -PSEdition Desktop
 
 function Get-ServiceLogonAccount {
     [cmdletbinding()]            

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ServiceDetails.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ServiceDetails.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ServiceDetails {
     [cmdletbinding(DefaultParameterSetName = 'default')]
 

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ServiceLogonAccount.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ServiceLogonAccount.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ServiceLogonAccount {
 	<#
 		$Servers = Get-ADComputer -Filter { OperatingSystem -Like '*Windows Server*' } | Select-Object Name

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-ServicePrivilege.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-ServicePrivilege.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ServicePrivilege {
     param
     (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-TargetGPResult.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-TargetGPResult.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 enum GpResultOutputMode {
     Summary      # Displays summary data (/R)
     Verbose      # Displays detailed settings with precedence 1 (/V)

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-TokenSizeReport.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-TokenSizeReport.ps1
@@ -101,6 +101,7 @@
   - Work out how to report on cross-forest/domain group memberships as neither tokenGroups or
     GetAuthorizationGroups() can achieve this.
 #>
+#requires -PSEdition Desktop
 
 #-------------------------------------------------------------
 

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-TopOUName.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-TopOUName.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-TopOUName {
 	<#
 		.SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-UnlinkedGPO.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-UnlinkedGPO.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 import-module grouppolicy
 
 function IsNotLinked($xmldata) {

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-UserLogon.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-UserLogon.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-UserLogon {
 	<#
 		.SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-UserLogonEvents.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-UserLogonEvents.ps1
@@ -42,6 +42,7 @@ http://scripts.lukeleigh.com/
 The help URI for more information about the Get-UserLogonEvents function.
 
 #>
+#requires -PSEdition Desktop
 function Get-UserLogonEvents {
     [CmdletBinding(DefaultParameterSetName = 'Default',
         ConfirmImpact = 'Medium',

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-UserSupportedEncryptionTypes.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-UserSupportedEncryptionTypes.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 Import-Module ActiveDirectory
 
 # Windows Server 2008 and above

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Get-UsersGroupMemberShips.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Get-UsersGroupMemberShips.ps1
@@ -4,6 +4,7 @@
   - http://blogs.technet.com/b/heyscriptingguy/archive/2009/10/08/hey-scripting-guy-october-8-2009.aspx
 
 #>
+#requires -PSEdition Desktop
 
 #-------------------------------------------------------------
 

--- a/PowerShell/UserAdminModule/ADFunctions/Public/GetMailboxPermission.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/GetMailboxPermission.ps1
@@ -1,4 +1,5 @@
 #Accept input paramenters
+#requires -PSEdition Desktop
 param(
     [switch]$FullAccess,
     [switch]$SendAs,

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Lock-UserAccount.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Lock-UserAccount.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Lock-UserAccount {
 
     <#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Move-ADComputer.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Move-ADComputer.ps1
@@ -21,6 +21,7 @@
     Version: 1.2
 
 #>
+#requires -PSEdition Desktop
 
 function Move-ADComputer {
     [CmdletBinding(SupportsShouldProcess = $true)]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Move-FSMORolestoPDCEmulator.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Move-FSMORolestoPDCEmulator.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Move-FSMORolestoPDCEmulator {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/New-FakeADUser.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/New-FakeADUser.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function New-FakeADUser {
 
     <#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/New-FakeADUserDetails.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/New-FakeADUserDetails.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function New-FakeADUserDetails {
     <#
         .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/New-FakeUserDetails.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/New-FakeUserDetails.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function New-FakeUserDetails {
     <#
         .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/New-RandomUser.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/New-RandomUser.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function New-RandomUser {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Provision_Home_Folder.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Provision_Home_Folder.ps1
@@ -14,6 +14,7 @@
   Modified by Jeremy@jhouseconsulting.com 24th April 2014
 
 #>
+#requires -PSEdition Desktop
 
 #-------------------------------------------------------------
 param([String]$Username, [String]$HomeDrive, [String]$HomeDirectory)

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Remove-AdminSDHolder.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Remove-AdminSDHolder.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Remove-AdminSDHolder {
     
     [CmdletBinding(

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Restore-ADDeletedUsers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Restore-ADDeletedUsers.ps1
@@ -11,6 +11,7 @@
     .EXAMPLE
     Restore-ADDeletedUsers -Usertorestore ATest
 #>
+#requires -PSEdition Desktop
 
 Function Restore-ADDeletedUsers {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Search-GPOforString.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Search-GPOforString.ps1
@@ -1,4 +1,5 @@
 # Import-Module GroupPolicy -SkipEditionCheck
+#requires -PSEdition Desktop
 
 function Search-GPOsForString {
     <#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Search-GPOsForString.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Search-GPOsForString.ps1
@@ -7,6 +7,7 @@
 # Comment: Simple search for GPOs within a domain 
 # that match a given string 
 ######################################################## 
+#requires -PSEdition Desktop
 
 function Search-GPOsForString {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Set-ADDiagnosticConfiguration.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Set-ADDiagnosticConfiguration.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-ADDiagnosticLogging {
     param (
         [Parameter(Mandatory = $true)]

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Set-ADUserPassword.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Set-ADUserPassword.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-ADUserPassword {
 	<#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Set-CustomAttributesForGroupMembers.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Set-CustomAttributesForGroupMembers.ps1
@@ -21,6 +21,7 @@
 .NOTES
     Requires ActiveDirectory module and appropriate permissions.
 #>
+#requires -PSEdition Desktop
 function Set-CustomAttributesForGroupMembers {
     [CmdletBinding(SupportsShouldProcess=$true)]
     param (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Set-ExtensionAttribute.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Set-ExtensionAttribute.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-ExtensionAttribute {
     [CmdletBinding(SupportsShouldProcess)]
     param (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Set-FSMORoleOwner.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Set-FSMORoleOwner.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-FSMORoleOwner {
 
     <#

--- a/PowerShell/UserAdminModule/ADFunctions/Public/SiteNameConsistencyReport.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/SiteNameConsistencyReport.ps1
@@ -10,6 +10,7 @@
   https://github.com/joethemongoose/PowerCLI/blob/master/Export-VMs-With-SiteCode.ps1
 
 #>
+#requires -PSEdition Desktop
 
 #-------------------------------------------------------------
 # Get the script path

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Sync-Office365ToADDS.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Sync-Office365ToADDS.ps1
@@ -117,6 +117,7 @@
 		Sync-Office365ToADDS -SyncUsers -PaswordForAllUsers "Temp123" "OU=Users,OU=Chicago,DC=lazyadmin,DC=com"
 		
 #>
+#requires -PSEdition Desktop
 function Sync-Office365ToADDS {
 	[CmdletBinding()]
 	Param (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Test-ADUserCredentials.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Test-ADUserCredentials.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-ADUserCredentials {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Test-ADUserHighPrivilegeGroupMembership.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Test-ADUserHighPrivilegeGroupMembership.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 Function Test-ADUserHighPrivilegeGroupMembership {
 
     ##########################################################################################################

--- a/PowerShell/UserAdminModule/ADFunctions/Public/Unlock-UserAccount.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/Unlock-UserAccount.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Unlock-UserAccount {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/ADFunctions/Public/remove-ADM.ps1
+++ b/PowerShell/UserAdminModule/ADFunctions/Public/remove-ADM.ps1
@@ -38,6 +38,7 @@
 #         -Restore: This switch tells the script to restore based on the contentsn of the file specified in the -logfile parameter.
 #
 ################################################################
+#requires -PSEdition Desktop
 
 param([string]$backupPath,
     [string]$logPath,        


### PR DESCRIPTION
## Summary
- add the `#requires -PSEdition Desktop` directive to every ADFunctions public script so the module only runs on Windows PowerShell Desktop edition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2ed36b7d4832d80d815bc72ee4464