### PR TITLE
Add PSEdition Desktop requirement to security and testing scripts

### DIFF
--- a/PowerShell/UserAdminModule/Security/Public/Disable-CiscoSecure.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Disable-CiscoSecure.ps1
@@ -16,6 +16,7 @@
    $Password = Read-Host "Enter your password" -AsSecureString
    Disable-CiscoSecure -Password $Password -ComputerName "Server01", "Server02"
 #>
+#requires -PSEdition Desktop
 function Disable-CiscoSecure {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Security/Public/Enable-CiscoSecure.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Enable-CiscoSecure.ps1
@@ -13,6 +13,7 @@
    Enable-CiscoSecure -ComputerName "Computer1", "Computer2", "Computer3"
    This command enables Cisco Secure on the computers named Computer1, Computer2, and Computer3.
 #>
+#requires -PSEdition Desktop
 function Enable-CiscoSecure {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Security/Public/Get-CimNamespacePermissions.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-CimNamespacePermissions.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-CimNamespacePermissions {
     param (
         [string]$namespace

--- a/PowerShell/UserAdminModule/Security/Public/Get-CimNamespacePermissionsRemote.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-CimNamespacePermissionsRemote.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-CimNamespacePermissionsRemote {
     param (
         [string]$computerName,

--- a/PowerShell/UserAdminModule/Security/Public/Get-CimPermsLocal.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-CimPermsLocal.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-CimPermsLocal {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Security/Public/Get-InsecureLDAPBinds.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-InsecureLDAPBinds.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-InsecureLDAPBinds {
 
 	<#-----------------------------------------------------------------------------

--- a/PowerShell/UserAdminModule/Security/Public/Get-NameSpacePerms.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-NameSpacePerms.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-NameSpacePerms {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Security/Public/Get-Namespaces.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-Namespaces.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-Namespaces {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Security/Public/Get-PSGalleryItemsForAuthor.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-PSGalleryItemsForAuthor.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-PSGalleryItemsForAuthor {
     <#PSScriptInfo
 

--- a/PowerShell/UserAdminModule/Security/Public/Get-PasswordAttempts.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-PasswordAttempts.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-PasswordAttempts {
 
 

--- a/PowerShell/UserAdminModule/Security/Public/Get-PasswordAttempts2.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-PasswordAttempts2.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-PasswordAttempts2 {
 
     <#

--- a/PowerShell/UserAdminModule/Security/Public/Get-ProductKey.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-ProductKey.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ProductKey {
     <#   
     .SYNOPSIS   

--- a/PowerShell/UserAdminModule/Security/Public/Get-SSLlabsScore.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-SSLlabsScore.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-SslLabsScore {
     [CmdletBinding()]
     Param(

--- a/PowerShell/UserAdminModule/Security/Public/Get-SettingsWithCPassword.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-SettingsWithCPassword.ps1
@@ -57,6 +57,7 @@ if (-not (Get-Module -name "GroupPolicy")) {
 else {
     $isGPModuleAvailable = $true
 }
+#requires -PSEdition Desktop
 Function Enum-SettingsWithCpassword ( [string]$sysvolLocation ) {
     # GPMC tree paths
     $commonPath = " -> Preferences -> Control Panel Settings -> "

--- a/PowerShell/UserAdminModule/Security/Public/Get-UnknownDevices.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-UnknownDevices.ps1
@@ -36,6 +36,7 @@ VendorID DeviceID DevMgrName                         LikelyName
    start http://www.Foxdeploy.com
    start http://deploymentresearch.com/Research/Post/306/Back-to-basics-Finding-Lenovo-drivers-and-certify-hardware-control-freak-style
 #>
+#requires -PSEdition Desktop
 Function Get-UnknownDevices{
 [CmdletBinding()]
 Param([ValidateScript({test-path (Split-Path $path)})]$Export,

--- a/PowerShell/UserAdminModule/Security/Public/Get-VpnFailoverEventLogs.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Get-VpnFailoverEventLogs.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-VpnFailoverEventLogs {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/Security/Public/Invoke-CiscoSecureManagement.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Invoke-CiscoSecureManagement.ps1
@@ -59,6 +59,7 @@
     Author: Your Name
     Date:   Current Date
 #>
+#requires -PSEdition Desktop
 function Invoke-CiscoSecureManagement {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (

--- a/PowerShell/UserAdminModule/Security/Public/Invoke-PasswordRoll.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Invoke-PasswordRoll.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Invoke-PasswordRoll
 {
 <#

--- a/PowerShell/UserAdminModule/Security/Public/Invoke-PasswordifyPhrase.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Invoke-PasswordifyPhrase.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Invoke-PasswordifyPhrase {
     <#
 	.SYNOPSIS

--- a/PowerShell/UserAdminModule/Security/Public/New-DynamicParameter.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/New-DynamicParameter.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-Example {
 	[CmdletBinding()]
 	param (

--- a/PowerShell/UserAdminModule/Security/Public/New-Password.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/New-Password.ps1
@@ -31,6 +31,7 @@ repeat	1-128	9	Indicates how many passwords to generate.
 
 #>
 
+#requires -PSEdition Desktop
 function New-Password {
     [CmdletBinding()]
     $Alphas = Invoke-RestMethod -Uri "https://passwordwolf.com/api/?length=8&upper=on&lower=on&numbers=off&special=off&repeat=1"

--- a/PowerShell/UserAdminModule/Security/Public/PasswordFunctions.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/PasswordFunctions.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Save-Password {
 <# Example
 

--- a/PowerShell/UserAdminModule/Security/Public/ScreenPassword.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/ScreenPassword.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function ScreenPassword($instance) {
     if (!($instance.screensaversecure)) { return $instance.name }
     <additional statements>

--- a/PowerShell/UserAdminModule/Security/Public/Set-CIMPermissions.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Set-CIMPermissions.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-CIMPermissions {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Security/Public/Set-LDAPSBinding.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Set-LDAPSBinding.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-LDAPSBinding {
     param (
         [Parameter(Mandatory=$true)]

--- a/PowerShell/UserAdminModule/Security/Public/Update-SSLCertificate.ps1
+++ b/PowerShell/UserAdminModule/Security/Public/Update-SSLCertificate.ps1
@@ -27,6 +27,7 @@
     Date: 2024-06-30
 #>
 
+#requires -PSEdition Desktop
 function Update-SSLCertificate {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ADReplication.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ADReplication.ps1
@@ -4,6 +4,7 @@
 # Import PoShLog
 Import-Module PoShLog
 
+#requires -PSEdition Desktop
 function Test-ADReplication {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/Testing/Public/Test-CiscoSecure.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-CiscoSecure.ps1
@@ -13,6 +13,7 @@
    Test-CiscoSecure -ComputerName "Computer1", "Computer2", "Computer3"
    This command checks the status of Cisco Secure Endpoint on the computers named Computer1, Computer2, and Computer3.
 #>
+#requires -PSEdition Desktop
 function Test-CiscoSecure {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Testing/Public/Test-Computer.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-Computer.ps1
@@ -1,4 +1,5 @@
-﻿function Test-Computer {
+﻿#requires -PSEdition Desktop
+function Test-Computer {
     <#
     .SYNOPSIS
     Tests a computer and returns its current status including DNS, RDP, AD, and DHCP IP address information.

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ComputerName.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ComputerName.ps1
@@ -29,6 +29,7 @@ Test-ComputerName -ComputerName server01,server02
 Description:
 Will perform the ping, RDP, DNS and AD checks for server01 and server02
 #>
+#requires -PSEdition Desktop
 Function Test-ComputerName {
     param (
         [CmdletBinding()]

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ContactEmail.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ContactEmail.ps1
@@ -18,6 +18,7 @@
     HelpUri: http://scripts.lukeleigh.com/
 #>
 
+#requires -PSEdition Desktop
 function Test-ContactEmail {
     [CmdletBinding(
         DefaultParameterSetName = 'Default',

--- a/PowerShell/UserAdminModule/Testing/Public/Test-DNSRecord.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-DNSRecord.ps1
@@ -157,6 +157,7 @@
     Where-Object - https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/where-object
 
 #>
+#requires -PSEdition Desktop
 function Test-DNSRecord {
     [CmdletBinding()]
 

--- a/PowerShell/UserAdminModule/Testing/Public/Test-DeathstarBackUp.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-DeathstarBackUp.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-DeathstarBackUp {
     Test-OpenPorts -ComputerName DEATHSTAR -Ports 80, 443, 445 # ,7878,8989,9117,49092
 }

--- a/PowerShell/UserAdminModule/Testing/Public/Test-DisplayName.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-DisplayName.ps1
@@ -17,6 +17,7 @@
     Date: 2024-06-30
 #>
 
+#requires -PSEdition Desktop
 function Test-DisplayName {
     [CmdletBinding()]
     param(

--- a/PowerShell/UserAdminModule/Testing/Public/Test-DnsRecordEndpoints.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-DnsRecordEndpoints.ps1
@@ -23,6 +23,7 @@
     Date: 2024-06-30
 #>
 
+#requires -PSEdition Desktop
 function Test-DnsRecordEndpoints {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Testing/Public/Test-DomainMailRecords.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-DomainMailRecords.ps1
@@ -27,6 +27,7 @@
     Date: Today's Date
 #>
 
+#requires -PSEdition Desktop
 function Test-DomainMailRecords {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ExchangeConnection.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ExchangeConnection.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-ExchangeConnection {
     $sessions = Get-PSSession
     $connections = Get-ConnectionInformation

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ExchangeDNSRR.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ExchangeDNSRR.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-ExchangeDNSRR {
     <#
         .SYNOPSIS

--- a/PowerShell/UserAdminModule/Testing/Public/Test-FileExists.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-FileExists.ps1
@@ -29,6 +29,7 @@ System.Boolean
 Author: Unknown
 Date: Unknown
 #>
+#requires -PSEdition Desktop
 function Test-FileExists {
     [CmdletBinding(
         DefaultParameterSetName = 'Default',

--- a/PowerShell/UserAdminModule/Testing/Public/Test-FolderExists.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-FolderExists.ps1
@@ -17,6 +17,7 @@
     Date: 2024-06-30
 #>
 
+#requires -PSEdition Desktop
 function Test-FolderExists {
     [CmdletBinding(
         DefaultParameterSetName = 'Default',

--- a/PowerShell/UserAdminModule/Testing/Public/Test-IsAdmin.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-IsAdmin.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-IsAdmin {
     <#
     .Synopsis

--- a/PowerShell/UserAdminModule/Testing/Public/Test-LDAPconnection.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-LDAPconnection.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-LDAPConnection {
     param (
         [Parameter(Mandatory=$true)]

--- a/PowerShell/UserAdminModule/Testing/Public/Test-NetworkPort.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-NetworkPort.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-NetworkPort {
 
 	<#

--- a/PowerShell/UserAdminModule/Testing/Public/Test-O365EmailExists.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-O365EmailExists.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-O365EmailExists {
     <#
 	.SYNOPSIS

--- a/PowerShell/UserAdminModule/Testing/Public/Test-OnlineFast.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-OnlineFast.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-OnlineFast {
     param
     (

--- a/PowerShell/UserAdminModule/Testing/Public/Test-OpenPorts.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-OpenPorts.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-OpenPorts {
 
     <#

--- a/PowerShell/UserAdminModule/Testing/Public/Test-OpenPortsWitch.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-OpenPortsWitch.ps1
@@ -120,6 +120,7 @@
         https://scripts.lukeleigh.com
 #>
 
+#requires -PSEdition Desktop
 function Test-OpenPortsWitch {
     
     [CmdletBinding(DefaultParameterSetName = 'Default',

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ProfileExists.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ProfileExists.ps1
@@ -14,6 +14,7 @@
     Date: 2024-06-30
 #>
 
+#requires -PSEdition Desktop
 function Test-ProfileExists {
     [CmdletBinding()]
     param ()

--- a/PowerShell/UserAdminModule/Testing/Public/Test-RemoteTimeSettings.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-RemoteTimeSettings.ps1
@@ -29,6 +29,7 @@
     $testResults | Format-List
 #>
 
+#requires -PSEdition Desktop
 function Test-RemoteTimeSettings {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Testing/Public/Test-SMB1Enabled.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-SMB1Enabled.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-SMB1Enabled {
     if (Get-SMBServerConfiguration | Where-Object -FilterScript { $_.EnableSMB1Protocol -eq $true }) {
         Write-Warning -Message "SMB1 is Enabled"

--- a/PowerShell/UserAdminModule/Testing/Public/Test-SSLProtocols.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-SSLProtocols.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-SSLProtocols {
 
    	<#

--- a/PowerShell/UserAdminModule/Testing/Public/Test-SamAccountName.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-SamAccountName.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-SamAccountName {
     param(
         [Parameter(Mandatory = $true)]

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ServerExists.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ServerExists.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 Function Test-ServerExists {
     param (
         [CmdletBinding()]

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ServerRolePortGroup.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ServerRolePortGroup.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-ServerRolePortGroup {
 	<#
 .SYNOPSIS

--- a/PowerShell/UserAdminModule/Testing/Public/Test-Surname.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-Surname.ps1
@@ -17,6 +17,7 @@
     Date: 2024-06-30
 #>
 
+#requires -PSEdition Desktop
 function Test-Surname {
     [CmdletBinding()]
     param(

--- a/PowerShell/UserAdminModule/Testing/Public/Test-TLSConnection.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-TLSConnection.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-TLSConnection {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/Testing/Public/Test-TransmissionSettings.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-TransmissionSettings.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-TransmissionSettings {
     <#
         .SYNOPSIS

--- a/PowerShell/UserAdminModule/Testing/Public/Test-UserExists.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-UserExists.ps1
@@ -17,6 +17,7 @@
     Date: 2024-06-30
 #>
 
+#requires -PSEdition Desktop
 function Test-UserExists {
     [CmdletBinding()]
     param(

--- a/PowerShell/UserAdminModule/Testing/Public/Test-WebSiteUp.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-WebSiteUp.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 Function Test-WebsiteUp {
 <#
 	.SYNOPSIS

--- a/PowerShell/UserAdminModule/Testing/Public/Test-WebsiteAvailability.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-WebsiteAvailability.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Test-WebsiteAvailability {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/Testing/Public/Test-ifContactExists.ps1
+++ b/PowerShell/UserAdminModule/Testing/Public/Test-ifContactExists.ps1
@@ -53,6 +53,7 @@
     Date:   Current Date
 #>
 
+#requires -PSEdition Desktop
 function Test-ifContactExists {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     Param(


### PR DESCRIPTION
## Summary
- add `#requires -PSEdition Desktop` before each security function to enforce Windows PowerShell execution
- add the same requirement across the testing scripts so they run under the desktop edition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2ed37875c832d87337fc6815124f1