### PR TITLE
Add Desktop edition requirement to GUI selection scripts

### DIFF
--- a/PowerShell/UserAdminModule/Shell/Public/Select-FolderLocation.ps1
+++ b/PowerShell/UserAdminModule/Shell/Public/Select-FolderLocation.ps1
@@ -1,3 +1,5 @@
+#requires -PSEdition Desktop
+
 function Select-FolderLocation {
     <#
     .SYNOPSIS

--- a/PowerShell/scripts/Exchange/Get-MailboxPermissionsScript.ps1
+++ b/PowerShell/scripts/Exchange/Get-MailboxPermissionsScript.ps1
@@ -1,3 +1,5 @@
+#requires -PSEdition Desktop
+
 function Select-FolderLocation {
     [Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms") | Out-Null
     [System.Windows.Forms.Application]::EnableVisualStyles()

--- a/PowerShell/scripts/activeDirectory/Get-LastLogonToCSV.ps1
+++ b/PowerShell/scripts/activeDirectory/Get-LastLogonToCSV.ps1
@@ -1,3 +1,5 @@
+#requires -PSEdition Desktop
+
 function Select-FolderLocation {
     [Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms") | Out-Null
     [System.Windows.Forms.Application]::EnableVisualStyles()


### PR DESCRIPTION
## Summary
- declare a Windows PowerShell requirement for the Select-FolderLocation helper in the module
- mark the Exchange mailbox permissions export script as Windows-only
- restrict the AD last logon export helper to the Desktop edition because it uses Windows Forms

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ed3ec40c832da1a12941d0559be2