### PR TITLE
Add Desktop edition requirement to ProcessServiceSchedules scripts

### DIFF
--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-AllScheduledScripts.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-AllScheduledScripts.ps1
@@ -27,6 +27,7 @@
     [Link to any related documentation or resources]
 
 #>
+#requires -PSEdition Desktop
 function Get-AllScheduledScripts {
     Get-ScheduledTask | Where-Object { $_.Actions.Execute -eq 'powershell.exe' } | ForEach-Object {
         $task = $_

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ProcessStatus.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ProcessStatus.ps1
@@ -39,6 +39,7 @@
     Author: Your Name
     Date: Current Date
 #>
+#requires -PSEdition Desktop
 
 function Get-ProcessStatus {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ProcessandServicePID.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ProcessandServicePID.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ProcessandServicePID {
     $ServicePids = (Get-Wmiobject win32_service).ProcessId | Sort-Object -Unique
     $ProcessPids = (Get-Process).Id | Sort-Object -Unique

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-RemoteScheduledTasks.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-RemoteScheduledTasks.ps1
@@ -23,6 +23,7 @@ Author: Your Name
 Date: Today's Date
 Version: 1.0
 #>
+#requires -PSEdition Desktop
 
 function Get-RemoteScheduledTasks {
     [CmdletBinding( DefaultParameterSetName = 'ComputerName', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ScheduledScripts.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ScheduledScripts.ps1
@@ -64,6 +64,7 @@
     [Link to any related documentation or resources]
 
 #>
+#requires -PSEdition Desktop
 function Get-ScheduledScripts {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ScheduledTasks.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ScheduledTasks.ps1
@@ -61,6 +61,7 @@
 .LINK
     http://scripts.lukeleigh.com/
 #>
+#requires -PSEdition Desktop
 function Get-ScheduledTasks {
     [CmdletBinding()]        
     param (

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ServiceStatus.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Get-ServiceStatus.ps1
@@ -71,6 +71,7 @@
 
     Retrieves and formats the status of services with display names matching the pattern "*Cisco*" on the specified computers.
 #>
+#requires -PSEdition Desktop
 
 function Get-ServiceStatus {
     [CmdletBinding(DefaultParameterSetName = 'Default')]

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/New-ScheduledScript.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/New-ScheduledScript.ps1
@@ -50,6 +50,7 @@ Creates a new scheduled task named "EnrollDCCertificate" that runs the script "C
 .NOTES
 This function requires administrative privileges to register the scheduled task with the Windows Task Scheduler.
 #>
+#requires -PSEdition Desktop
 function New-ScheduledScript {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/New-ScheduledTask.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/New-ScheduledTask.ps1
@@ -46,6 +46,7 @@ Write-Output "Q: Press 'Q' to quit."
 
 BEGIN {
     # [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+#requires -PSEdition Desktop
     function New-Entry {
         $NewEvent = [PSCustomObject]@{
             LogName   = 'System'

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Remove-ScheduledScript.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Remove-ScheduledScript.ps1
@@ -37,6 +37,7 @@ Date: Today's Date
 .LINK
 https://docs.microsoft.com/en-us/powershell/module/scheduledtasks/unregister-scheduledtask?view=windowsserver2019-ps
 #>
+#requires -PSEdition Desktop
 function Remove-ScheduledScript {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Restart-NinjaRMMService.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Restart-NinjaRMMService.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Restart-NinjaRMMService {
 
     <#

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Restart-PrintSpooler.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Restart-PrintSpooler.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Restart-PrintSpooler
 {
 	<#

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Set-PrintSpoolerConfig.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Set-PrintSpoolerConfig.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-PrintSpoolerConfig {
 
 	<#

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Set-ServiceConfig.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Set-ServiceConfig.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-ServiceConfig {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-BullwallServices.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-BullwallServices.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Start-RansomcareServices {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-Outlook.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-Outlook.ps1
@@ -18,6 +18,7 @@ Start-Outlook -UseOldVersion
 Starts the old version of Microsoft Outlook.
 
 #>
+#requires -PSEdition Desktop
 function Start-Outlook {
     param (
         [Parameter(Mandatory = $false, HelpMessage = "Use this switch to start the old version of Outlook.")]

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-ProcessOnComputer.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-ProcessOnComputer.ps1
@@ -21,6 +21,7 @@ Start-ProcessOnComputer -ComputerName "Server01" -Name "notepad.exe"
 
 Starts the notepad.exe process on the computer named Server01.
 #>
+#requires -PSEdition Desktop
 function Start-ProcessOnComputer {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
     param (

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-ScheduledScript.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-ScheduledScript.ps1
@@ -14,6 +14,7 @@ Start-ScheduledScript -TaskName "MyTask"
 This example starts the scheduled task named "MyTask".
 
 #>
+#requires -PSEdition Desktop
 function Start-ScheduledScript {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-ServicesInOrder.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-ServicesInOrder.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Start-ServicesInOder {
 
     <#

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-TaskList.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Start-TaskList.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Start-TaskList {
     $PSDefaultParameterValues['Write-Progress:Activity'] = $phrase
     $phrases = Get-Content -Path C:\GitRepos\TextFiles\prankphrases.txt

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Stop-FailedService.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Stop-FailedService.ps1
@@ -20,6 +20,7 @@
     Author: Your Name
     Date: 2024-06-30
 #>
+#requires -PSEdition Desktop
 
 function Stop-FailedService {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Stop-NonRespondingProcesses.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Stop-NonRespondingProcesses.ps1
@@ -17,6 +17,7 @@
     Author: Your Name
     Date: 2024-06-30
 #>
+#requires -PSEdition Desktop
 
 function Stop-NonRespondingProcesses {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Stop-ProcessOnComputer.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Stop-ProcessOnComputer.ps1
@@ -32,6 +32,7 @@ Stop-ProcessOnComputer -ComputerName "Server1" -Name "Notepad" -Force
 
 This example forcefully stops the Notepad process on Server1.
 #>
+#requires -PSEdition Desktop
 function Stop-ProcessOnComputer {
     [CmdletBinding(SupportsShouldProcess = $true, DefaultParameterSetName = 'Default')]
     param (

--- a/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Stop-ScheduledScript.ps1
+++ b/PowerShell/UserAdminModule/ProcessServiceSchedules/Public/Stop-ScheduledScript.ps1
@@ -24,6 +24,7 @@
     Date:   Current Date
 
 #>
+#requires -PSEdition Desktop
 function Stop-ScheduledScript {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (


### PR DESCRIPTION
## Summary
- add the `#requires -PSEdition Desktop` directive before each ProcessServiceSchedules public function to ensure these scripts target the desktop edition of PowerShell.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2ed450d6c832dab5c64af66889735