### PR TITLE
Add Desktop PowerShell requirement to AD functions

### DIFF
--- a/PowerShell/NewFunctions/Get-GroupMembers.ps1
+++ b/PowerShell/NewFunctions/Get-GroupMembers.ps1
@@ -25,6 +25,7 @@
 .INPUTS
     [string]GroupName
 #>
+#requires -PSEdition Desktop
 function Get-GroupMembers {
     [CmdletBinding(DefaultParameterSetName = 'Default',
         PositionalBinding = $true,

--- a/PowerShell/NewFunctions/Get-GroupNames.ps1
+++ b/PowerShell/NewFunctions/Get-GroupNames.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-GroupNames {
 
     <#


### PR DESCRIPTION
## Summary
- add the Desktop edition requirement directive before the Get-GroupNames function
- add the Desktop edition requirement directive before the Get-GroupMembers function

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2ed4b08cc832d9c7ad050d97001fd