### PR TITLE
Add Desktop edition requirement to utility scripts

### DIFF
--- a/PowerShell/UserAdminModule/Utilities/Public/Get-ServerInstalledFeatures.ps1
+++ b/PowerShell/UserAdminModule/Utilities/Public/Get-ServerInstalledFeatures.ps1
@@ -31,6 +31,7 @@
 .LINK
     Get-WindowsFeature
 #>
+#requires -PSEdition Desktop
 
 function Get-ServerInstalledFeatures {
     [CmdletBinding(SupportsShouldProcess = $true)]

--- a/PowerShell/UserAdminModule/Utilities/Public/Get-UserProfiles.ps1
+++ b/PowerShell/UserAdminModule/Utilities/Public/Get-UserProfiles.ps1
@@ -35,6 +35,7 @@ This function requires administrative privileges on the remote server.
 https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters
 
 #>
+#requires -PSEdition Desktop
 
 function Get-UserProfiles {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]

--- a/PowerShell/UserAdminModule/Utilities/Public/Get-W32TimeConfiguration.ps1
+++ b/PowerShell/UserAdminModule/Utilities/Public/Get-W32TimeConfiguration.ps1
@@ -51,6 +51,7 @@ A custom PSObject representing the W32Time configuration with the following prop
 Author: Your Name
 Date:   Current Date
 #>
+#requires -PSEdition Desktop
 
 function Get-W32TimeConfiguration {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/Utilities/Public/Get-W32TimeServiceStatus.ps1
+++ b/PowerShell/UserAdminModule/Utilities/Public/Get-W32TimeServiceStatus.ps1
@@ -27,6 +27,7 @@ This function requires administrative privileges to retrieve the service status 
 .LINK
 Get-Service
 #>
+#requires -PSEdition Desktop
 
 function Get-W32TimeServiceStatus {
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/Utilities/Public/Get-W32TimeSource.ps1
+++ b/PowerShell/UserAdminModule/Utilities/Public/Get-W32TimeSource.ps1
@@ -45,6 +45,8 @@ Author: Your Name
 Date: Current Date
 Version: 1.0
 #>
+#requires -PSEdition Desktop
+
 function Get-W32TimeSource {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Utilities/Public/Get-W32TimeStripchartResults.ps1
+++ b/PowerShell/UserAdminModule/Utilities/Public/Get-W32TimeStripchartResults.ps1
@@ -23,6 +23,8 @@
     Author: Your Name
     Date:   Current Date
 #>
+#requires -PSEdition Desktop
+
 function Get-W32TimeStripchartResults {
     [CmdletBinding()]
     param (


### PR DESCRIPTION
## Summary
- add `#requires -PSEdition Desktop` headers to the W32Time utility scripts
- add the same requirement to the Get-ServerInstalledFeatures and Get-UserProfiles utilities

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ed5c1f84832da39feca1687ca03e