### PR TITLE
Add Desktop edition requirement to remote and network scripts

### DIFF
--- a/PowerShell/NewFunctions/Connect-Proxy.ps1
+++ b/PowerShell/NewFunctions/Connect-Proxy.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 $Wcl = new-object System.Net.WebClient
 $Wcl.Headers.Add(“user-agent”, “PowerShell Script”)
 $Wcl.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials

--- a/PowerShell/NewFunctions/Logoff-Stale-RDP.ps1
+++ b/PowerShell/NewFunctions/Logoff-Stale-RDP.ps1
@@ -14,6 +14,7 @@
    PS > .\Logoff-DisconnectedSession.ps1
 #>
 
+#requires -PSEdition Desktop
 function Test-LogFilePath([string]$LogFilePath) {
    if (!(Test-Path -Path $LogFilePath)) { New-Item $LogFilePath -ItemType directory >> $null }
 }

--- a/PowerShell/UserAdminModule/Network/Public/Get-CidrIPRange.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-CidrIPRange.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-CidrIPRange {
 
     <#

--- a/PowerShell/UserAdminModule/Network/Public/Get-ComputerIP.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-ComputerIP.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ComputerIP {
     <#
         .SYNOPSIS

--- a/PowerShell/UserAdminModule/Network/Public/Get-HostIOResults.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-HostIOResults.ps1
@@ -19,6 +19,7 @@
 .NOTES
     This function requires an active internet connection to access the host.io API.
 #>
+#requires -PSEdition Desktop
 function Get-HostIOResults {
     [CmdletBinding()]
 

--- a/PowerShell/UserAdminModule/Network/Public/Get-MullvadApiDetails.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-MullvadApiDetails.ps1
@@ -55,6 +55,7 @@ results         : {}
 organization    : Virgin Media
 #>
 
+#requires -PSEdition Desktop
 function Get-MullvadApiDetails {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Network/Public/Get-PortService.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-PortService.ps1
@@ -72,6 +72,7 @@ class PortService {
     }
 }
 
+#requires -PSEdition Desktop
 function Get-PortService {
     [CmdletBinding()]
     param(

--- a/PowerShell/UserAdminModule/Network/Public/Get-RemoteIPSettings.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-RemoteIPSettings.ps1
@@ -11,6 +11,7 @@
     This function is as remote as it gets—bringing your network details right to your console!
 #>
 
+#requires -PSEdition Desktop
 function Get-RemoteIPSettings {
     [CmdletBinding()]
     param(

--- a/PowerShell/UserAdminModule/Network/Public/Get-RemoteServerPorts.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-RemoteServerPorts.ps1
@@ -31,6 +31,7 @@
     Get-RemoteServerPorts -ComputerName "EXCHANGE01" -Credential (Get-Credential)
 #>
 
+#requires -PSEdition Desktop
 function Get-RemoteServerPorts {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Network/Public/Get-ServerIPInfo.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-ServerIPInfo.ps1
@@ -27,6 +27,7 @@ This function requires the Active Directory module and administrative privileges
 https://github.com/your-repo/Get-ServerIPInfo.ps1
 #>
 
+#requires -PSEdition Desktop
 function Get-ServerIPInfo {
     $ServerList = (Get-ADComputer -Filter 'operatingsystem -like "*server*" -and enabled -eq "true"').Name
     $test = Test-Connection -ComputerName $ServerList -Count 1 -ErrorAction SilentlyContinue

--- a/PowerShell/UserAdminModule/Network/Public/Get-WTFismyIP.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-WTFismyIP.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-WTFismyIP {
     [CmdletBinding()]
 

--- a/PowerShell/UserAdminModule/Network/Public/Get-WhoIsInformation.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-WhoIsInformation.ps1
@@ -21,6 +21,7 @@ Author: Your Name
 Date:   Current Date
 #>
 # Define a function to get WHOIS information for a list of domain names
+#requires -PSEdition Desktop
 function Get-WhoIsInformation {
     # Use CmdletBinding to enable advanced function features
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/Network/Public/Get-ipInfo.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Get-ipInfo.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-ipInfo {
 
     <#

--- a/PowerShell/UserAdminModule/Network/Public/Send-MagicPacket.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Send-MagicPacket.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Send-MagicPacket {
 	<#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/Network/Public/Set-DHCPIPAddress.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Set-DHCPIPAddress.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-DHCPIPAddress {
 	<#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/Network/Public/Set-GoogleDynamicDNS.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Set-GoogleDynamicDNS.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-GoogleDynamicDNS {
 
     <#

--- a/PowerShell/UserAdminModule/Network/Public/Set-StaticIPAddress.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Set-StaticIPAddress.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-StaticIPAddress {
 	<#
 	.SYNOPSIS

--- a/PowerShell/UserAdminModule/Network/Public/Set-WMIPermissions.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Set-WMIPermissions.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-WMIPermissions {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/Network/Public/Switch-VpnFailover.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Switch-VpnFailover.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Switch-VpnFailover {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/Network/Public/Switch-VpnFailoverMac.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Switch-VpnFailoverMac.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Switch-VpnFailoverMac {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/Network/Public/Update-CloudflareDDNS.ps1
+++ b/PowerShell/UserAdminModule/Network/Public/Update-CloudflareDDNS.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Update-CloudflareDDNS {
 
     <#

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-CmRcViewer.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-CmRcViewer.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 Function Connect-CmRcViewer {
 	<#
 	.SYNOPSIS

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-InternalPRTG.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-InternalPRTG.ps1
@@ -22,6 +22,7 @@ Get-ADComputer -Filter { Name -like '*PRTG*' } | Connect-InternalPRTG
 Retrieves the computer names that match the filter '*PRTG*' from Active Directory and connects to each PRTG server using the current user's credentials.
 
 #>
+#requires -PSEdition Desktop
 function Connect-InternalPRTG {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-Mstsc.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-Mstsc.ps1
@@ -29,6 +29,7 @@
 .RELEASENOTES
 
 #>
+#requires -PSEdition Desktop
 function Connect-Mstsc {
 <#   
 .SYNOPSIS   

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-PSExec.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-PSExec.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Connect-PSExec {
     <#
 	.SYNOPSIS

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-PSExecPowershell.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-PSExecPowershell.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Connect-PSExecPowershell {
     <#
 	.SYNOPSIS

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-RDPSession.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-RDPSession.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 Function Connect-RDPSession {
 	<#
 	.SYNOPSIS

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-RemoteAssistance.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Connect-RemoteAssistance.ps1
@@ -19,6 +19,7 @@ Connects to the remote computer named "skywalker" using Remote Assistance.
 
 #>
 
+#requires -PSEdition Desktop
 function Connect-RemoteAssistance {
     [CmdletBinding()]
     param (

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Disable-RDPRemotely.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Disable-RDPRemotely.ps1
@@ -28,6 +28,7 @@ Disables RDP on the computers 'Server01' and 'Server02'.
 Disables RDP on the computers 'Desktop01' and 'Desktop02' using pipeline input.
 
 #>
+#requires -PSEdition Desktop
 function Disable-RDPRemotely {
     [CmdletBinding(DefaultParameterSetName = 'Default',
         ConfirmImpact = 'Medium',

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Disable-RDPRemotelyCIM.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Disable-RDPRemotelyCIM.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Disable-RDPRemotelyCIM {
     # You can also disable it using the below method.
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Disable-RDPRemotelyWMI.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Disable-RDPRemotelyWMI.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Disable-RDPRemotelyWMI {
     # You can also disable it using the below method.
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Enable-RDPRemotely.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Enable-RDPRemotely.ps1
@@ -27,6 +27,7 @@ Author: Your Name
 Date: Today's Date
 Version: 1.0
 #>
+#requires -PSEdition Desktop
 function Enable-RDPRemotely {
     [CmdletBinding(DefaultParameterSetName = 'Default',
         ConfirmImpact = 'Medium',

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Enable-RDPRemotelyCIM.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Enable-RDPRemotelyCIM.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Enable-RDPRemotelyCIM {
     # You can enable RDP on a remote host by simply running the below two lines.
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Enable-RDPRemotelyWMI.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Enable-RDPRemotelyWMI.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Enable-RDPRemotelyWMI {
     # You can enable RDP on a remote host by simply running the below two lines.
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Enable-RemoteDesktop.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Enable-RemoteDesktop.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Enable-RemoteDesktop {
  
     <# 

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Get-LoggedOnRDPUser.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Get-LoggedOnRDPUser.ps1
@@ -30,6 +30,7 @@
     Website: http://scripts.lukeleigh.com/
     Version: 1.0
 #>
+#requires -PSEdition Desktop
 function Get-LoggedOnRDPUser {
 
     [CmdletBinding(DefaultParameterSetName = 'Default',

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Get-RDPStatus.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Get-RDPStatus.ps1
@@ -1,4 +1,5 @@
 # Function: Get-RDPStatus
+#requires -PSEdition Desktop
 Function Get-RDPStatus {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Get-RDPStatusCIM.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Get-RDPStatusCIM.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-RDPStatusCIM {
     # Do you care to check if it is currently enabled or disabled before acting? Use the below code.
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Get-RDPStatusWMI.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Get-RDPStatusWMI.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Get-RDPStatusWMI {
     # Do you care to check if it is currently enabled or disabled before acting? Use the below code.
     [CmdletBinding()]

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Get-RDPUserReport.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Get-RDPUserReport.ps1
@@ -1,4 +1,5 @@
 # Function: Get-RDPUserReport
+#requires -PSEdition Desktop
 Function Get-RDPUserReport {
     <#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Remove-RDPUserSession.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Remove-RDPUserSession.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Remove-RDPUserSession {
 	<#
     .SYNOPSIS

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Set-RDPRemotely.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Set-RDPRemotely.ps1
@@ -1,3 +1,4 @@
+#requires -PSEdition Desktop
 function Set-RDPRemotely {
     [CmdletBinding(DefaultParameterSetName = 'Default',
         ConfirmImpact = 'Medium',

--- a/PowerShell/UserAdminModule/RemoteConnections/Public/Set-RDPStatus.ps1
+++ b/PowerShell/UserAdminModule/RemoteConnections/Public/Set-RDPStatus.ps1
@@ -1,4 +1,5 @@
 # Function: Set-RDPStatus
+#requires -PSEdition Desktop
 Function Set-RDPStatus {
     <#
     .SYNOPSIS


### PR DESCRIPTION
## Summary
- add `#requires -PSEdition Desktop` to all remote connection scripts so they declare their Windows PowerShell dependency
- add the same requirement to each network script to keep platform requirements consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2ed63cd28832db0205237d8212c7d