### PR TITLE
Add Desktop edition requirement to file management scripts

### DIFF
--- a/PowerShell/scripts/fileManagement/DataDriveSizes.ps1
+++ b/PowerShell/scripts/fileManagement/DataDriveSizes.ps1
@@ -1,3 +1,5 @@
+#requires -PSEdition Desktop
+
 function Get-FriendlySize {
     param($Bytes)
     $sizes = 'Bytes,KB,MB,GB,TB,PB,EB,ZB' -split ','

--- a/PowerShell/scripts/fileManagement/FileSizes.ps1
+++ b/PowerShell/scripts/fileManagement/FileSizes.ps1
@@ -1,3 +1,5 @@
+#requires -PSEdition Desktop
+
 function Get-FriendlySize {
     param($Bytes)
     $sizes = 'Bytes,KB,MB,GB,TB,PB,EB,ZB' -split ','


### PR DESCRIPTION
## Summary
- add `#requires -PSEdition Desktop` to the DataDriveSizes and FileSizes file operations scripts

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2ed67fff4832d9f224c2fabce897a